### PR TITLE
[Feat/#7] 버튼 컴포넌트 구현

### DIFF
--- a/src/components/common/button.tsx
+++ b/src/components/common/button.tsx
@@ -1,27 +1,23 @@
-type TButtonType = 'primary' | 'alert' | 'disabled' | 'outlined';
+type TButtonVariant = 'primary' | 'alert' | 'disabled' | 'outlined';
 
-interface IButtonProps {
-  children: React.ReactNode;
-  type?: TButtonType;
-  onClick?: () => void;
-  className?: string;
+interface IButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: TButtonVariant;
 }
 
-const typeStyles: Record<TButtonType, string> = {
+const variantStyles: Record<TButtonVariant, string> = {
   primary: 'bg-primary-60 text-white hover:cursor-pointer hover:opacity-90',
   alert: 'bg-alert text-white hover:cursor-pointer hover:opacity-90',
   disabled: 'bg-coolgray-30 text-white cursor-not-allowed',
   outlined: 'bg-white border border-primary-60 text-primary-60 hover:cursor-pointer hover:opacity-90',
 };
 
-export default function Button({ children, type = 'primary', onClick, className = '' }: IButtonProps) {
+export default function Button({ children, variant = 'primary', className = '', disabled, ...props }: IButtonProps) {
   const baseStyles = 'p-4 rounded-sm text-button-s flex items-center justify-center';
-
   return (
     <button
-      onClick={onClick}
-      disabled={type === 'disabled'}
-      className={`${baseStyles} ${typeStyles[type]} ${className}`}
+      {...props}
+      disabled={disabled || variant === 'disabled'}
+      className={`${baseStyles} ${variantStyles[variant]} ${className}`}
     >
       {children}
     </button>

--- a/src/components/common/button.tsx
+++ b/src/components/common/button.tsx
@@ -1,0 +1,29 @@
+type TButtonType = 'primary' | 'alert' | 'disabled' | 'outlined';
+
+interface IButtonProps {
+  children: React.ReactNode;
+  type?: TButtonType;
+  onClick?: () => void;
+  className?: string;
+}
+
+const typeStyles: Record<TButtonType, string> = {
+  primary: 'bg-primary-60 text-white hover:cursor-pointer hover:opacity-90',
+  alert: 'bg-alert text-white hover:cursor-pointer hover:opacity-90',
+  disabled: 'bg-coolgray-30 text-white cursor-not-allowed',
+  outlined: 'bg-white border border-primary-60 text-primary-60 hover:cursor-pointer hover:opacity-90',
+};
+
+export default function Button({ children, type = 'primary', onClick, className = '' }: IButtonProps) {
+  const baseStyles = 'p-4 rounded-sm text-button-s flex items-center justify-center';
+
+  return (
+    <button
+      onClick={onClick}
+      disabled={type === 'disabled'}
+      className={`${baseStyles} ${typeStyles[type]} ${className}`}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -65,7 +65,7 @@
   /* Button */
   .text-button-s {
     font-size: 16px;
-    font-weight: 600;
+    font-weight: 400;
     line-height: 16px;
     letter-spacing: 0.5px;
   }

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,4 +1,5 @@
 import Icon from '@/assets/Icon.svg?react';
+import Button from '@/components/common/button';
 
 export default function Home() {
   return (
@@ -37,6 +38,20 @@ export default function Home() {
       <p className="text-heading-5 text-chip-red bg-chip-red-bg">text-chip-red</p>
       <p className="text-heading-5 text-alert">text-alert</p>
       <p className="text-heading-5 text-success">text-success</p>
+
+      {/* Buttons */}
+      <div className="w-full flex items-center justify-center gap-4">
+        <Button className="w-40">primary</Button>
+        <Button type="alert" className="w-40">
+          alert
+        </Button>
+        <Button type="disabled" className="w-40">
+          disabled
+        </Button>
+        <Button type="outlined" className="w-40">
+          outlined
+        </Button>
+      </div>
     </>
   );
 }

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -42,13 +42,13 @@ export default function Home() {
       {/* Buttons */}
       <div className="w-full flex items-center justify-center gap-4">
         <Button className="w-40">primary</Button>
-        <Button type="alert" className="w-40">
+        <Button variant="alert" className="w-40">
           alert
         </Button>
-        <Button type="disabled" className="w-40">
+        <Button variant="disabled" className="w-40">
           disabled
         </Button>
-        <Button type="outlined" className="w-40">
+        <Button variant="outlined" className="w-40">
           outlined
         </Button>
       </div>


### PR DESCRIPTION
## 📋 작업 내용
- 버튼 컴포넌트 구현

## 🎯 관련 이슈
- closes #7 

## 📝 변경 사항
- home.tsx에 예제 추가
- 생각보다 실제 크기가 큰 이슈로.. css 수정

## 📸 스크린샷 (선택사항)
<!--
필요한 경우 스크린샷 첨부
-->
<img width="2849" height="109" alt="image" src="https://github.com/user-attachments/assets/ccd29dd4-4b27-4a03-bb79-9c3be79c593b" />