### PR TITLE
[Feat] 카카오 OAuth 로그인 및 라우팅 게이트 구현

### DIFF
--- a/src/apis/auth/auth.ts
+++ b/src/apis/auth/auth.ts
@@ -1,0 +1,15 @@
+import axiosInstance from '@/apis/axiosInstance';
+import type { TPostOnboardingRequest } from '@/types/auth/TPostOnboarding';
+import type { TCommonResponse } from '@/types/common';
+
+// 카카오 로그인 후 최초 1회 학번/이름을 저장해 회원 정보를 완성한다.
+export const postOnboarding = async (body: TPostOnboardingRequest) => {
+  const { data } = await axiosInstance.post<TCommonResponse<null>>('/api/users/me/onboarding', body);
+  return data;
+};
+
+// 리프레시 토큰 쿠키를 삭제해 로그아웃 처리한다.
+export const postLogout = async () => {
+  const { data } = await axiosInstance.post<TCommonResponse<null>>('/auth/logout');
+  return data;
+};

--- a/src/apis/user/user.ts
+++ b/src/apis/user/user.ts
@@ -1,0 +1,8 @@
+import axiosInstance from '@/apis/axiosInstance';
+import type { TGetUserInfoResponse } from '@/types/user/TGetUserInfo';
+
+// 로그인한 사용자 정보 조회
+export const getUserInfo = async () => {
+  const { data } = await axiosInstance.get<TGetUserInfoResponse>('/api/users/me');
+  return data.result;
+};

--- a/src/components/onBoardingModal.tsx
+++ b/src/components/onBoardingModal.tsx
@@ -1,15 +1,14 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 import Button from '@/components/common/button';
 import TextField from '@/components/common/textField';
+import useOnboarding from '@/hooks/auth/useOnboarding';
 import { useModalStore } from '@/stores/modalStore';
 
 export default function OnBoardingModal() {
   const { type, closeModal } = useModalStore();
-  const navigate = useNavigate();
+  const { mutate: submitOnboarding, isPending } = useOnboarding();
   const [name, setName] = useState('');
-  const [nickname, setNickname] = useState('');
   const [studentId, setStudentId] = useState('');
   const [agreedPrivacy, setAgreedPrivacy] = useState(false);
   const [agreedTerms, setAgreedTerms] = useState(false);
@@ -17,10 +16,9 @@ export default function OnBoardingModal() {
 
   if (type !== 'onboarding') return null;
 
+  // 온보딩 정보 저장. 성공 시 홈 이동은 useOnboarding이 처리하고, 여기서는 모달만 닫는다.
   const handleSubmit = () => {
-    // TODO: API 연결
-    closeModal();
-    navigate('/');
+    submitOnboarding({ studentId, name }, { onSuccess: () => closeModal() });
   };
 
   return (
@@ -34,10 +32,6 @@ export default function OnBoardingModal() {
           <label className="flex flex-col gap-1">
             <span className="text-body-m">이름</span>
             <TextField placeholder="김동국" value={name} onChange={(e) => setName(e.target.value)} />
-          </label>
-          <label className="flex flex-col gap-1">
-            <span className="text-body-m">닉네임</span>
-            <TextField placeholder="동그리" value={nickname} onChange={(e) => setNickname(e.target.value)} />
           </label>
           <label className="flex flex-col gap-1">
             <span className="text-body-m">학번</span>
@@ -89,7 +83,7 @@ export default function OnBoardingModal() {
         <Button
           className="w-full text-body-l py-3"
           onClick={handleSubmit}
-          disabled={!name || !nickname || !studentId || !agreedAge || !agreedPrivacy || !agreedTerms}
+          disabled={!name || !studentId || !agreedAge || !agreedPrivacy || !agreedTerms || isPending}
         >
           동그리 시작하기
         </Button>

--- a/src/hooks/auth/useLogout.ts
+++ b/src/hooks/auth/useLogout.ts
@@ -1,0 +1,24 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+
+import { postLogout } from '@/apis/auth/auth';
+import { useCoreMutation } from '@/hooks/customQuery';
+import { useAuthStore } from '@/stores/authStore';
+import type { TCommonResponse } from '@/types/common';
+
+// 로그아웃 훅.
+// 성공 시 메모리의 accessToken을 비우고, 쿼리 캐시를 정리한 뒤 로그인 화면으로 이동한다.
+// 호출 시 별도 변수가 필요 없으므로 mutation 변수 타입을 void로 지정한다. (logout() 형태로 호출)
+export default function useLogout() {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const clearAuth = useAuthStore((state) => state.clearAuth);
+
+  return useCoreMutation<TCommonResponse<null>, void>(() => postLogout(), {
+    onSuccess: () => {
+      clearAuth();
+      queryClient.clear();
+      navigate('/');
+    },
+  });
+}

--- a/src/hooks/auth/useOnboarding.ts
+++ b/src/hooks/auth/useOnboarding.ts
@@ -1,0 +1,21 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+
+import { postOnboarding } from '@/apis/auth/auth';
+import { QUERY_KEYS } from '@/constants/querykeys/queryKeys';
+import { useCoreMutation } from '@/hooks/customQuery';
+import type { TPostOnboardingRequest } from '@/types/auth/TPostOnboarding';
+
+// 온보딩 정보 저장 훅
+// 성공 시 사용자 정보 캐시를 무효화하고(온보딩 완료 반영) 홈으로 이동시킨다.
+export default function useOnboarding() {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  return useCoreMutation((body: TPostOnboardingRequest) => postOnboarding(body), {
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.GET_USER_INFO });
+      navigate('/');
+    },
+  });
+}

--- a/src/hooks/customQuery.ts
+++ b/src/hooks/customQuery.ts
@@ -22,7 +22,7 @@ export function useCoreQuery<TQueryFnData, TData = TQueryFnData>(
     // 인증 실패(401)는 재시도해도 결과가 같아 backoff 지연만 늘어나므로 즉시 중단한다.
     // 그 외 일시적 오류는 기존처럼 최대 3회까지 재시도한다.
     retry: (failureCount, error) => {
-      if ((error as TResponseError).response?.status === 401) return false;
+      if (error && (error as TResponseError).response?.status === 401) return false;
       return failureCount < 3;
     },
     ...options,

--- a/src/hooks/customQuery.ts
+++ b/src/hooks/customQuery.ts
@@ -19,6 +19,12 @@ export function useCoreQuery<TQueryFnData, TData = TQueryFnData>(
     queryKey: keyName,
     queryFn: query,
     staleTime: 1000 * 60 * 5,
+    // 인증 실패(401)는 재시도해도 결과가 같아 backoff 지연만 늘어나므로 즉시 중단한다.
+    // 그 외 일시적 오류는 기존처럼 최대 3회까지 재시도한다.
+    retry: (failureCount, error) => {
+      if ((error as TResponseError).response?.status === 401) return false;
+      return failureCount < 3;
+    },
     ...options,
   });
 }

--- a/src/hooks/user/useUserInfo.ts
+++ b/src/hooks/user/useUserInfo.ts
@@ -1,0 +1,10 @@
+import { getUserInfo } from '@/apis/user/user';
+import { QUERY_KEYS } from '@/constants/querykeys/queryKeys';
+import { useCoreQuery } from '@/hooks/customQuery';
+
+// 사용자 정보 조회 훅
+// 라우팅 게이트(인증/온보딩 판단)와 화면 표시에 함께 쓰이므로
+// data뿐 아니라 isPending/isError 등 query 상태 전체를 반환한다.
+export default function useUserInfo() {
+  return useCoreQuery(QUERY_KEYS.GET_USER_INFO, () => getUserInfo());
+}

--- a/src/pages/authCallback.tsx
+++ b/src/pages/authCallback.tsx
@@ -1,15 +1,18 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { getUserInfo } from '@/apis/user/user';
 import Loading from '@/components/common/loading';
+import { QUERY_KEYS } from '@/constants/querykeys/queryKeys';
 import { useAuthStore } from '@/stores/authStore';
 
 // 카카오 OAuth 로그인 성공 후 백엔드가 리다이렉트하는 콜백 페이지.
 // 백엔드는 accessToken을 쿼리 파라미터로 직접 전달하고, refreshToken은 HttpOnly 쿠키로 심는다.
 export default function AuthCallback() {
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const setAccessToken = useAuthStore((state) => state.setAccessToken);
   const clearAuth = useAuthStore((state) => state.clearAuth);
   // StrictMode에서 useEffect가 두 번 실행되는 것을 막아 토큰 처리/이동이 중복되지 않게 한다.
@@ -28,12 +31,15 @@ export default function AuthCallback() {
 
     // accessToken을 메모리에 저장하고, 브라우저 히스토리/주소창에 토큰이 남지 않도록
     // 쿼리스트링을 즉시 제거한다. (URL 노출로 인한 토큰 유출 위험 최소화)
+    // React Router 내부 상태와 URL을 일치시키기 위해 setSearchParams를 사용한다.
     setAccessToken(accessToken);
-    window.history.replaceState(null, '', window.location.pathname);
+    setSearchParams({}, { replace: true });
 
     // 사용자 정보를 조회해 온보딩 여부로 분기한다.
     getUserInfo()
       .then((user) => {
+        // 조회 결과를 캐시에 미리 심어, 이동한 페이지에서 useUserInfo가 중복 요청하지 않게 한다.
+        queryClient.setQueryData(QUERY_KEYS.GET_USER_INFO, user);
         // studentId가 없으면 온보딩 미완료 → 온보딩으로 강제, 완료 상태면 홈으로.
         navigate(user.studentId === null ? '/onboarding' : '/', { replace: true });
       })
@@ -42,7 +48,7 @@ export default function AuthCallback() {
         clearAuth();
         navigate('/login', { replace: true });
       });
-  }, [searchParams, navigate, setAccessToken, clearAuth]);
+  }, [searchParams, setSearchParams, navigate, queryClient, setAccessToken, clearAuth]);
 
   return (
     <div className="min-h-dvh flex flex-col">

--- a/src/pages/authCallback.tsx
+++ b/src/pages/authCallback.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useRef } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+
+import { getUserInfo } from '@/apis/user/user';
+import Loading from '@/components/common/loading';
+import { useAuthStore } from '@/stores/authStore';
+
+// 카카오 OAuth 로그인 성공 후 백엔드가 리다이렉트하는 콜백 페이지.
+// 백엔드는 accessToken을 쿼리 파라미터로 직접 전달하고, refreshToken은 HttpOnly 쿠키로 심는다.
+export default function AuthCallback() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const setAccessToken = useAuthStore((state) => state.setAccessToken);
+  const clearAuth = useAuthStore((state) => state.clearAuth);
+  // StrictMode에서 useEffect가 두 번 실행되는 것을 막아 토큰 처리/이동이 중복되지 않게 한다.
+  const handledRef = useRef(false);
+
+  useEffect(() => {
+    if (handledRef.current) return;
+    handledRef.current = true;
+
+    const accessToken = searchParams.get('accessToken');
+    // 토큰이 없으면 비정상 진입이므로 로그인 화면으로 되돌린다.
+    if (!accessToken) {
+      navigate('/login', { replace: true });
+      return;
+    }
+
+    // accessToken을 메모리에 저장하고, 브라우저 히스토리/주소창에 토큰이 남지 않도록
+    // 쿼리스트링을 즉시 제거한다. (URL 노출로 인한 토큰 유출 위험 최소화)
+    setAccessToken(accessToken);
+    window.history.replaceState(null, '', window.location.pathname);
+
+    // 사용자 정보를 조회해 온보딩 여부로 분기한다.
+    getUserInfo()
+      .then((user) => {
+        // studentId가 없으면 온보딩 미완료 → 온보딩으로 강제, 완료 상태면 홈으로.
+        navigate(user.studentId === null ? '/onboarding' : '/', { replace: true });
+      })
+      .catch(() => {
+        // 조회 실패 시 저장한 토큰을 정리하고 로그인으로 되돌린다.
+        clearAuth();
+        navigate('/login', { replace: true });
+      });
+  }, [searchParams, navigate, setAccessToken, clearAuth]);
+
+  return (
+    <div className="min-h-dvh flex flex-col">
+      <Loading />
+    </div>
+  );
+}

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -2,6 +2,12 @@ import Kakao from '@/assets/kakao.svg?react';
 import Logo from '@/assets/logo.svg?react';
 
 export default function Login() {
+  // 카카오 로그인 시작: 백엔드의 Spring Security OAuth2 진입점으로 이동시킨다.
+  // 이후 콜백/토큰 발급은 백엔드가 처리하고 /auth/callback으로 돌아온다.
+  const handleKakaoLogin = () => {
+    window.location.href = `${import.meta.env.VITE_API_URL}/oauth2/authorization/kakao`;
+  };
+
   return (
     <div className="flex items-center justify-center h-screen bg-primary-30">
       <div className="flex flex-col items-center gap-12 rounded-md bg-white py-20 px-42">
@@ -11,6 +17,7 @@ export default function Login() {
         </div>
         <button
           type="button"
+          onClick={handleKakaoLogin}
           className="flex items-center justify-center gap-4 bg-[#FEE500] rounded-md px-20 py-3 cursor-pointer hover:opacity-90"
         >
           <Kakao className="w-7 h-7" />

--- a/src/pages/myPage.tsx
+++ b/src/pages/myPage.tsx
@@ -3,10 +3,13 @@ import { Link } from 'react-router-dom';
 import Edit from '@/assets/icons/edit.svg?react';
 import Setting from '@/assets/icons/setting.svg?react';
 import User from '@/assets/icons/user.svg?react';
+import Button from '@/components/common/button';
+import useLogout from '@/hooks/auth/useLogout';
 import useInView from '@/hooks/useInView';
 
 export default function MyPage() {
   const [ref, isInView] = useInView();
+  const { mutate: logout, isPending } = useLogout();
 
   return (
     <div
@@ -31,6 +34,10 @@ export default function MyPage() {
           <p className="text-heading-3 text-coolgray-90">내 학업 정보 관리</p>
         </Link>
       </div>
+      {/* 마이페이지 하단 중앙 로그아웃 버튼 (탈퇴하기 버튼과 동일한 양식) */}
+      <Button variant="alert" className="w-40" onClick={() => logout()} disabled={isPending}>
+        로그아웃
+      </Button>
     </div>
   );
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -2,6 +2,7 @@ import { createBrowserRouter } from 'react-router-dom';
 
 import Layout from '@/layouts';
 import AcademicRecords from '@/pages/academicRecords';
+import AuthCallback from '@/pages/authCallback';
 import Curriculum from '@/pages/curriculum';
 import Graduation from '@/pages/graduation';
 import Home from '@/pages/home';
@@ -11,26 +12,37 @@ import NotFound from '@/pages/notFound';
 import OnBoarding from '@/pages/onBoarding';
 import Profile from '@/pages/profile';
 import UploadPage from '@/pages/uploadPage';
+import ProtectedRoute from '@/routes/protectedRoute';
 
 export const router = createBrowserRouter([
+  // 인증 없이 접근 가능한 라우트 (로그인, OAuth 콜백)
   { path: '/login', element: <Login /> },
+  { path: '/auth/callback', element: <AuthCallback /> },
   {
     path: '/',
     element: <Layout />,
     children: [
+      // 홈(랜딩)은 인증 없이 접근 가능한 public 라우트.
       { index: true, element: <Home /> },
+      // 그 외 라우트는 ProtectedRoute(인증 → 온보딩 게이트)를 통과해야 한다.
       {
-        path: 'my-page',
+        element: <ProtectedRoute />,
         children: [
-          { index: true, element: <MyPage /> },
-          { path: 'profile', element: <Profile /> },
-          { path: 'academic-records', element: <AcademicRecords /> },
+          {
+            path: 'my-page',
+            children: [
+              { index: true, element: <MyPage /> },
+              { path: 'profile', element: <Profile /> },
+              { path: 'academic-records', element: <AcademicRecords /> },
+            ],
+          },
+          { path: 'curriculum', element: <Curriculum /> },
+          { path: 'graduation', element: <Graduation /> },
+          { path: 'onboarding', element: <OnBoarding /> },
+          { path: 'upload', element: <UploadPage /> },
         ],
       },
-      { path: 'curriculum', element: <Curriculum /> },
-      { path: 'graduation', element: <Graduation /> },
-      { path: 'onboarding', element: <OnBoarding /> },
-      { path: 'upload', element: <UploadPage /> },
+      // 정의되지 않은 경로는 인증과 무관하게 NotFound를 보여준다. (public)
       { path: '*', element: <NotFound /> },
     ],
   },

--- a/src/routes/protectedRoute.tsx
+++ b/src/routes/protectedRoute.tsx
@@ -1,0 +1,39 @@
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+
+import Loading from '@/components/common/loading';
+import useUserInfo from '@/hooks/user/useUserInfo';
+
+// 2단 라우팅 게이트.
+// 1) 인증 게이트: 사용자 정보 조회 실패(미인증) 시 로그인 화면으로 보낸다.
+//    (401이면 axios 인터셉터가 refresh를 시도하고, 그래도 실패하면 여기서 /login으로 처리)
+// 2) 온보딩 게이트: 온보딩 미완료(studentId === null)면 무조건 온보딩 화면으로 강제하고,
+//    완료한 사용자가 온보딩 화면에 진입하면 홈으로 돌려보낸다.
+export default function ProtectedRoute() {
+  const { data, isPending, isError } = useUserInfo();
+  const { pathname } = useLocation();
+
+  // 인증 확인이 끝날 때까지 기존 공용 로딩 컴포넌트를 보여준다.
+  // (이 컴포넌트는 Layout의 Outlet 자리에 렌더되므로 Header/Footer 사이를 flex-1로 채운다)
+  if (isPending) {
+    return <Loading />;
+  }
+
+  // 미인증: 로그인 화면으로.
+  if (isError || !data) {
+    return <Navigate to="/login" replace />;
+  }
+
+  const needsOnboarding = data.studentId === null;
+  const onOnboardingPage = pathname === '/onboarding';
+
+  // 온보딩 미완료자는 온보딩 화면에서만 머무를 수 있다. (스킵 불가)
+  if (needsOnboarding && !onOnboardingPage) {
+    return <Navigate to="/onboarding" replace />;
+  }
+  // 이미 온보딩을 마친 사용자는 온보딩 화면에 들어올 수 없다.
+  if (!needsOnboarding && onOnboardingPage) {
+    return <Navigate to="/" replace />;
+  }
+
+  return <Outlet />;
+}

--- a/src/types/auth/TPostOnboarding.ts
+++ b/src/types/auth/TPostOnboarding.ts
@@ -1,0 +1,5 @@
+// POST /api/users/me/onboarding
+export type TPostOnboardingRequest = {
+  studentId: string;
+  name: string;
+};

--- a/src/types/user/TGetUserInfo.ts
+++ b/src/types/user/TGetUserInfo.ts
@@ -1,0 +1,10 @@
+import type { TCommonResponse } from '@/types/common';
+
+// GET /api/users/me 응답
+// 로그인만 완료하고 온보딩 전이면 studentId, name, nickname 모두 null로 내려온다.
+export type TGetUserInfoResponse = TCommonResponse<{
+  studentId: string | null;
+  name: string | null;
+  nickname: string | null;
+  identityVerified: boolean;
+}>;


### PR DESCRIPTION
## 📋 작업 내용
- 카카오 OAuth 로그인 플로우 구현
- 인증 / 온보딩 2단 라우팅 게이트 구현

## 🎯 관련 이슈
- closes #35

## 📝 변경 사항
- 카카오 OAuth 로그인: 로그인 버튼 → `/oauth2/authorization/kakao` 진입
- OAuth 콜백 페이지(`/auth/callback`): accessToken 쿼리파라미터 추출 → 저장 → URL 즉시 정리 → 온보딩 여부로 분기
- ProtectedRoute: 인증 게이트(미인증 → /login) + 온보딩 게이트(studentId null → /onboarding 강제, 완료자 진입 차단)
- 라우트 분리: Layout · Home · NotFound는 public, 그 외는 protected
- 사용자 정보 조회 / 온보딩 / 로그아웃 API · 훅 연결
- 온보딩 모달 API 연결 및 nickname 필드 제거 (온보딩 스펙은 studentId, name만)
- 마이페이지 로그아웃 버튼 추가
- useCoreQuery 401 재시도 비활성화로 인증 확인 로딩 지연 제거

## 📸 스크린샷 (선택사항)
<!--
필요한 경우 스크린샷 첨부
-->
