### PR TITLE
[Feat] 학업 리포트 생성 API 연동 구현

### DIFF
--- a/src/apis/report/report.ts
+++ b/src/apis/report/report.ts
@@ -1,0 +1,13 @@
+import axiosInstance from '@/apis/axiosInstance';
+import type { TPutTranscriptResponse } from '@/types/report/TPutTranscript';
+
+// 성적표 PDF 업로드 (multipart/form-data, 파트명 'file').
+// 서버가 PDF를 파싱해 학업 정보를 저장하며, 기존 성적표가 있으면 soft-delete 후 새로 생성한다.
+// 성공 코드는 COMMON201_1이며, result로 학점 정합성 정보(totalCredits/recordedCredits/creditGap)를 돌려준다.
+export const putTranscript = async (file: File) => {
+  const formData = new FormData();
+  formData.append('file', file);
+  // FormData를 전달하면 axios가 multipart 경계(boundary)를 자동으로 설정한다. (Content-Type 수동 지정 금지)
+  const { data } = await axiosInstance.put<TPutTranscriptResponse>('/api/users/me/reports', formData);
+  return data;
+};

--- a/src/constants/report/creditGapModals.tsx
+++ b/src/constants/report/creditGapModals.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from 'react';
+
+// 성적표 업로드는 성공했지만 학점 정합성(creditGap !== 0)이 맞지 않을 때 안내할 모달 문구.
+// 리포트 자체는 생성됐으므로, 모달 확인 후 졸업 판정(/graduation) 화면으로 이동한다.
+// icon/buttonText 등은 훅에서 일괄 부여하고, 여기서는 텍스트만 관리한다.
+// creditGap 값을 문구에 노출하기 위해 각 분기를 creditGap을 받는 함수로 둔다.
+// (음수 분기는 절대값으로 표시해 자연스러운 문장이 되도록 한다)
+type TCreditGapModalContent = {
+  title: string;
+  subtitle: ReactNode;
+  description: string;
+};
+
+// creditGap 학점 수치 부분만 primary-60 색으로 강조한다.
+const highlightCredit = (value: number) => <span className="text-primary-60">{value}학점</span>;
+
+export const CREDIT_GAP_MODAL = {
+  // 양수: PDF 총취득학점 > 인식된 과목 학점 합 → 누락된 수강 이력을 추가해야 함
+  positive: (creditGap: number): TCreditGapModalContent => ({
+    title: '동그리가 정확한 분석에 실패했어요',
+    subtitle: <>동그리가 찾은 학점이 실제 수강한 학점보다 {highlightCredit(creditGap)} 모자라요.</>,
+    description:
+      '지금 제공하는 리포트는 정확하지 않을 수 있어요.\n리포트 하단의 내 학업 정보 추가에서 누락된 과목을 추가해주세요.',
+  }),
+  // 음수: 인식된 과목 학점 합 > PDF 총취득학점 → 과목이 더 많이 인식됨(중복 등)
+  negative: (creditGap: number): TCreditGapModalContent => ({
+    title: '동그리가 정확한 분석에 실패했어요',
+    subtitle: <>동그리가 찾은 학점이 실제 수강한 학점보다 {highlightCredit(Math.abs(creditGap))} 많아요.</>,
+    description: '지금 제공하는 리포트는 정확하지 않을 수 있어요.\n문제가 있다면 고객지원에 문의해주세요.',
+  }),
+};

--- a/src/constants/report/transcriptErrorModals.ts
+++ b/src/constants/report/transcriptErrorModals.ts
@@ -1,0 +1,33 @@
+// 성적표 업로드(PUT /api/users/me/reports) 실패 시 alert 모달로 안내할 에러 코드별 문구.
+// 모달을 띄우는 에러만 정의한다. (404·500은 NotFound로 이동, 파일 누락 등은 토스트로 처리)
+// icon/buttonText 등은 훅에서 일괄 부여하고, 여기서는 텍스트만 관리한다.
+export const TRANSCRIPT_ERROR_MODAL: Record<string, { title: string; subtitle: string; description: string }> = {
+  // PDF 텍스트 추출 실패 (INVALID_PDF_FILE)
+  TRANSCRIPT400_2: {
+    title: '파일 읽기에 실패했어요',
+    subtitle: '파일이 손상되었거나 형식이 올바르지 않아요',
+    description:
+      '안내된 다운로드 방법에 따라 정확한 파일을 업로드해주세요.\n다른 문제가 있다면 고객지원에 문의해주세요.',
+  },
+  // 필수 메타 필드(학번·성명 등) 누락 (PDF_PARSING_FAILED)
+  TRANSCRIPT400_1: {
+    title: 'PDF 형식이 올바르지 않아요',
+    subtitle: '업로드한 파일이 취득교과목 영역별 분류표가 맞나요?',
+    description:
+      '안내된 다운로드 방법에 따라 정확한 파일을 업로드해주세요.\n다른 문제가 있다면 고객지원에 문의해주세요.',
+  },
+  // PDF 학과가 커리큘럼에 미등록 (DEPARTMENT_NOT_FOUND)
+  TRANSCRIPT400_3: {
+    title: '동그리가 아직 지원하지 않는 학과예요',
+    subtitle: '해당 학과의 졸업 요건이 등록되어 있지 않아요',
+    description:
+      '고객지원에 PDF 데이터를 제공하면 더 빠른 지원이 가능해요.\n다른 문제가 있다면 고객지원에 문의해주세요.',
+  },
+  // 본인 인증 정보와 PDF 학번/이름 불일치 (PDF_OWNER_MISMATCH)
+  USER403_1: {
+    title: '사용자 정보와 PDF 정보가 일치하지 않아요',
+    subtitle: '동그리는 타인의 PDF 업로드를 허용하지 않아요.',
+    description:
+      '사용자 정보를 잘못 입력했다면 마이페이지에서 수정해주세요.\n다른 문제가 있다면 고객지원에 문의해주세요.',
+  },
+};

--- a/src/hooks/customQuery.ts
+++ b/src/hooks/customQuery.ts
@@ -36,9 +36,9 @@ export function useCoreMutation<T, U>(mutation: MutationFunction<T, U>, options?
     mutationFn: mutation,
     // either/or: 호출자가 onError를 직접 제공하면 그쪽에 위임하고(직접 토스트/모달 등 처리),
     // 없으면 공용 기본 토스트로 안내한다. (토스트와 커스텀 처리가 동시에 뜨지 않도록)
-    onError: (error: TResponseError) => {
+    onError: (error: TResponseError, variables: U, context: unknown) => {
       if (onError) {
-        onError(error);
+        onError(error, variables, context);
       } else {
         toast.error(error.response?.data?.message ?? '요청 처리 중 오류가 발생했습니다.');
       }

--- a/src/hooks/customQuery.ts
+++ b/src/hooks/customQuery.ts
@@ -30,12 +30,19 @@ export function useCoreQuery<TQueryFnData, TData = TQueryFnData>(
 }
 
 export function useCoreMutation<T, U>(mutation: MutationFunction<T, U>, options?: TUseMutationCustomOptions<T, U>) {
+  // onError를 분리해 스프레드(...restOptions)가 아래 기본 핸들러를 덮어쓰지 않게 한다.
+  const { onError, ...restOptions } = options ?? {};
   return useMutation({
     mutationFn: mutation,
+    // either/or: 호출자가 onError를 직접 제공하면 그쪽에 위임하고(직접 토스트/모달 등 처리),
+    // 없으면 공용 기본 토스트로 안내한다. (토스트와 커스텀 처리가 동시에 뜨지 않도록)
     onError: (error: TResponseError) => {
-      toast.error(error.response?.data?.message ?? '요청 처리 중 오류가 발생했습니다.');
-      options?.onError?.(error);
+      if (onError) {
+        onError(error);
+      } else {
+        toast.error(error.response?.data?.message ?? '요청 처리 중 오류가 발생했습니다.');
+      }
     },
-    ...options,
+    ...restOptions,
   });
 }

--- a/src/hooks/report/useUploadTranscript.ts
+++ b/src/hooks/report/useUploadTranscript.ts
@@ -1,0 +1,78 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+
+import { putTranscript } from '@/apis/report/report';
+import Warning from '@/assets/icons/warning.svg?react';
+import { QUERY_KEYS } from '@/constants/querykeys/queryKeys';
+import { CREDIT_GAP_MODAL } from '@/constants/report/creditGapModals';
+import { TRANSCRIPT_ERROR_MODAL } from '@/constants/report/transcriptErrorModals';
+import { useCoreMutation } from '@/hooks/customQuery';
+import { useModalStore } from '@/stores/modalStore';
+import type { TResponseError } from '@/types/common';
+import type { TPutTranscriptResponse } from '@/types/report/TPutTranscript';
+
+// 성적표 PDF 업로드 훅.
+// 성공 시 관련 조회 캐시를 무효화하고 졸업 판정 화면으로 이동한다.
+// 실패 시 에러 코드/상태에 따라 NotFound 이동 · alert 모달 · 토스트로 분기한다.
+export default function useUploadTranscript() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const openAlert = useModalStore((state) => state.openAlert);
+
+  return useCoreMutation((file: File) => putTranscript(file), {
+    onSuccess: (data: TPutTranscriptResponse) => {
+      // 성적표가 새로 저장됐으므로 관련 조회 캐시를 먼저 무효화한다. (어느 분기든 공통)
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.GET_USER_REPORTS });
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.GET_REPORT_SUMMARY });
+
+      // creditGap = 총취득학점 - 과목 학점 합. 0이면 정합성 정상이므로 바로 졸업 판정으로 이동한다.
+      const { creditGap } = data.result;
+      if (creditGap === 0) {
+        navigate('/graduation');
+        return;
+      }
+
+      // 0이 아니면 리포트는 생성됐지만 학점 정합성이 맞지 않는 상태.
+      // 부호에 따라 다른 안내 모달을 띄우고, 확인 시 졸업 판정 화면으로 이동시킨다.
+      const modal = creditGap > 0 ? CREDIT_GAP_MODAL.positive(creditGap) : CREDIT_GAP_MODAL.negative(creditGap);
+      openAlert({
+        icon: Warning,
+        title: modal.title,
+        subtitle: modal.subtitle,
+        description: modal.description,
+        buttonText: '리포트 보기',
+        buttonVariant: 'primary',
+        onConfirm: () => navigate('/graduation'),
+      });
+    },
+    // either/or 정책상 onError를 직접 제공하므로 공용 기본 토스트는 뜨지 않는다. (중복 알림 방지)
+    onError: (error: TResponseError) => {
+      const status = error.response?.status;
+      const code = error.response?.data?.code;
+
+      // 회원 조회 실패(404)·서버 내부 오류(500)는 사용자가 조치할 수 없으므로 NotFound로 보낸다.
+      if (status === 404 || status === 500) {
+        navigate('/404', { replace: true });
+        return;
+      }
+
+      // 에러 코드에 해당하는 모달 문구가 있으면 alert 모달로 안내하고 업로드 화면에 머문다.
+      const modal = code ? TRANSCRIPT_ERROR_MODAL[code] : undefined;
+      if (modal) {
+        openAlert({
+          icon: Warning,
+          title: modal.title,
+          subtitle: modal.subtitle,
+          description: modal.description,
+          buttonText: '닫기',
+          buttonVariant: 'primary',
+        });
+        return;
+      }
+
+      // 그 외 예기치 못한 에러는 토스트로 안내한다. (예: 서버까지 전달된 파일 누락 등)
+      toast.error(error.response?.data?.message ?? '업로드 중 오류가 발생했습니다.');
+    },
+  });
+}

--- a/src/pages/uploadPage.tsx
+++ b/src/pages/uploadPage.tsx
@@ -1,5 +1,4 @@
 import { useRef, useState } from 'react';
-import { toast } from 'sonner';
 
 import Inbox from '@/assets/icons/inbox.svg?react';
 import Upload from '@/assets/icons/upload.svg?react';
@@ -15,12 +14,10 @@ export default function UploadPage() {
   const { mutate: uploadTranscript, isPending } = useUploadTranscript();
 
   // '졸업 판정 시작' 클릭 핸들러.
-  // 파일 미선택은 프론트에서 막을 수 있는 에러이므로 요청을 보내지 않고 토스트로 안내한다. (서버 TRANSCRIPT400_5 선제 차단)
+  // 파일이 없으면 버튼이 비활성화되므로 이 핸들러는 파일이 있을 때만 호출된다.
+  // (아래 null 가드는 타입 안전을 위한 방어 코드)
   const handleSubmit = () => {
-    if (!file) {
-      toast.error('성적표 PDF를 먼저 업로드해주세요.');
-      return;
-    }
+    if (!file) return;
     uploadTranscript(file);
   };
 

--- a/src/pages/uploadPage.tsx
+++ b/src/pages/uploadPage.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from 'react';
+import { toast } from 'sonner';
 
 import Inbox from '@/assets/icons/inbox.svg?react';
 import Upload from '@/assets/icons/upload.svg?react';
@@ -6,10 +7,22 @@ import UploadInfo1 from '@/assets/uploadInfo1.svg?react';
 import UploadInfo2 from '@/assets/uploadInfo2.svg?react';
 import UploadInfo3 from '@/assets/uploadInfo3.svg?react';
 import Button from '@/components/common/button';
+import useUploadTranscript from '@/hooks/report/useUploadTranscript';
 
 export default function UploadPage() {
   const [file, setFile] = useState<File | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const { mutate: uploadTranscript, isPending } = useUploadTranscript();
+
+  // '졸업 판정 시작' 클릭 핸들러.
+  // 파일 미선택은 프론트에서 막을 수 있는 에러이므로 요청을 보내지 않고 토스트로 안내한다. (서버 TRANSCRIPT400_5 선제 차단)
+  const handleSubmit = () => {
+    if (!file) {
+      toast.error('성적표 PDF를 먼저 업로드해주세요.');
+      return;
+    }
+    uploadTranscript(file);
+  };
 
   return (
     <div className="w-full flex flex-col items-center justify-center gap-20 p-20 text-coolgray-90">
@@ -100,8 +113,13 @@ export default function UploadPage() {
             동그리는 PDF에서 졸업 판정에 필요하지 않은 정보를 수집하지 않습니다.
           </p>
         </div>
-        <Button className="px-15 text-body-l" variant={file ? 'primary' : 'disabled'}>
-          졸업 판정 시작
+        <Button
+          className="px-15 text-body-l"
+          variant={file && !isPending ? 'primary' : 'disabled'}
+          disabled={!file || isPending}
+          onClick={handleSubmit}
+        >
+          {isPending ? '판정 중...' : '졸업 판정 시작'}
         </Button>
       </div>
     </div>

--- a/src/stores/modalStore.ts
+++ b/src/stores/modalStore.ts
@@ -1,4 +1,4 @@
-import type { ComponentType, SVGProps } from 'react';
+import type { ComponentType, ReactNode, SVGProps } from 'react';
 import { create } from 'zustand';
 
 type TModalType = 'alert' | 'onboarding';
@@ -6,7 +6,8 @@ type TModalType = 'alert' | 'onboarding';
 interface IAlertContent {
   icon: ComponentType<SVGProps<SVGSVGElement>>;
   title: string;
-  subtitle: string;
+  // 문구 일부에 색상 강조(span 등)를 넣을 수 있도록 문자열뿐 아니라 ReactNode를 허용한다.
+  subtitle: ReactNode;
   description: string;
   buttonText?: string;
   buttonVariant?: 'primary' | 'alert' | 'disabled' | 'outlined';

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -14,7 +14,9 @@ export type TUseMutationCustomOptions<TData = unknown, TVariables = unknown> = O
   UseMutationOptions<TData, TResponseError, TVariables, unknown>,
   'mutationFn' | 'onError'
 > & {
-  onError?: (error: TResponseError) => void;
+  // React Query 표준 시그니처에 맞춰 error 외 variables/context도 받을 수 있게 한다.
+  // (error만 받는 핸들러도 그대로 할당 가능 — 후행 인자는 무시되므로 하위호환)
+  onError?: (error: TResponseError, variables: TVariables, context: unknown) => void;
 };
 
 export type TUseQueryCustomOptions<TQueryFnData = unknown, TData = TQueryFnData> = Omit<

--- a/src/types/report/TPutTranscript.ts
+++ b/src/types/report/TPutTranscript.ts
@@ -1,0 +1,11 @@
+import type { TCommonResponse } from '@/types/common';
+
+// 성적표 업로드 성공 응답의 result.
+// creditGap = totalCredits - recordedCredits. 0이면 정합성 OK, 0이 아니면 불일치.
+export type TPutTranscriptResult = {
+  totalCredits: number; // PDF에 기재된 총취득학점
+  recordedCredits: number; // 등록된 수강 이력 학점의 합
+  creditGap: number; // 총취득학점 - 과목 학점 합 (양수: 이수 이력 추가 필요, 음수: 과목 합이 더 많음)
+};
+
+export type TPutTranscriptResponse = TCommonResponse<TPutTranscriptResult>;


### PR DESCRIPTION
## 📋 작업 내용
- 성적표 PDF 업로드(PUT /api/users/me/reports)를 업로드 페이지에 연동

## 🎯 관련 이슈
- closes #37 

## 📝 변경 사항
### 업로드 플로우
- '졸업 판정 시작' 클릭 → 파일 미선택 시 토스트로 선제 차단(요청 미발송)
- 업로드 중 버튼 비활성화 + '판정 중...' 표시

### 성공 처리 (학점 정합성 분기)
- 응답 result의 `creditGap`(= 총취득학점 − 과목 학점 합)으로 분기
- `creditGap === 0` → 바로 `/graduation` 이동
- `creditGap !== 0` → 정합성 안내 모달 표시 후 확인 시 `/graduation` 이동
  - 양수(이력 누락)/음수(과목 합 초과)별 문구 분기, 학점 수치 강조
- 성공 시 관련 조회 캐시(GET_USER_REPORTS·GET_REPORT_SUMMARY) 무효화

### 에러 처리
- 404·500 → NotFound 페이지로 이동
- 비즈니스 에러(PDF 추출 실패/파싱 실패/미등록 학과/본인 불일치) → alert 모달, 화면 유지
- 프론트에서 막을 수 있는 파일 누락 → 토스트

### 공통 인프라 변경
- `useCoreMutation` onError를 either/or로 변경 (커스텀 onError 제공 시 기본 토스트 생략 → 토스트·모달 중복 방지)
- alert 모달 `subtitle` 타입을 `ReactNode`로 확장 (문구 일부 색상 강조 지원, 하위호환)
## 📸 스크린샷 (선택사항)
<!--
필요한 경우 스크린샷 첨부
-->
