### PR TITLE
[Refactor] 인증·공통 응답 명세 정합성 보강

### DIFF
--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-import { SESSION_HINT_KEY, useAuthStore } from '@/stores/authStore';
+import { hasSessionHint, useAuthStore } from '@/stores/authStore';
 
 const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_URL,
@@ -29,7 +29,7 @@ axiosInstance.interceptors.response.use(
     // 한 번도 로그인한 적 없는(세션 힌트 없는) 사용자는 refreshToken 쿠키도 없으므로,
     // refresh를 시도해봐야 400(쿠키 없음)으로 실패할 뿐이다. 불필요한 왕복을 막기 위해 바로 거절한다.
     // (미인증 상태에서 보호 경로 진입 시 발생하던 refresh 호출 1회를 제거)
-    if (!localStorage.getItem(SESSION_HINT_KEY)) {
+    if (!hasSessionHint()) {
       return Promise.reject(error);
     }
 

--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-import { useAuthStore } from '@/stores/authStore';
+import { SESSION_HINT_KEY, useAuthStore } from '@/stores/authStore';
 
 const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_URL,
@@ -23,6 +23,13 @@ axiosInstance.interceptors.response.use(
     const originalRequest = error.config;
 
     if (error.response?.status !== 401 || originalRequest._retry) {
+      return Promise.reject(error);
+    }
+
+    // 한 번도 로그인한 적 없는(세션 힌트 없는) 사용자는 refreshToken 쿠키도 없으므로,
+    // refresh를 시도해봐야 400(쿠키 없음)으로 실패할 뿐이다. 불필요한 왕복을 막기 위해 바로 거절한다.
+    // (미인증 상태에서 보호 경로 진입 시 발생하던 refresh 호출 1회를 제거)
+    if (!localStorage.getItem(SESSION_HINT_KEY)) {
       return Promise.reject(error);
     }
 

--- a/src/hooks/customQuery.ts
+++ b/src/hooks/customQuery.ts
@@ -19,10 +19,12 @@ export function useCoreQuery<TQueryFnData, TData = TQueryFnData>(
     queryKey: keyName,
     queryFn: query,
     staleTime: 1000 * 60 * 5,
-    // 인증 실패(401)는 재시도해도 결과가 같아 backoff 지연만 늘어나므로 즉시 중단한다.
-    // 그 외 일시적 오류는 기존처럼 최대 3회까지 재시도한다.
+    // 4xx(인증 실패·리소스 없음 등)는 재시도해도 결과가 같아 backoff 지연만 늘어나므로 즉시 중단한다.
+    // 특히 401은 이미 axios 인터셉터가 refresh를 시도한 "최종 실패"라 여기서 또 재시도할 이유가 없다.
+    // 서버 오류(5xx)·네트워크 오류 같은 일시적 실패만 기존처럼 최대 3회 재시도한다.
     retry: (failureCount, error) => {
-      if (error && (error as TResponseError).response?.status === 401) return false;
+      const status = (error as TResponseError)?.response?.status;
+      if (status && status >= 400 && status < 500) return false;
       return failureCount < 3;
     },
     ...options,

--- a/src/hooks/report/useUploadTranscript.ts
+++ b/src/hooks/report/useUploadTranscript.ts
@@ -25,6 +25,9 @@ export default function useUploadTranscript() {
       // 성적표가 새로 저장됐으므로 관련 조회 캐시를 먼저 무효화한다. (어느 분기든 공통)
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.GET_USER_REPORTS });
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.GET_REPORT_SUMMARY });
+      // 업로드한 PDF의 학번/이름이 일치하면 서버가 그 시점에 본인 인증(identityVerified)을 자동 처리하므로,
+      // 사용자 정보 캐시도 무효화해 최신 인증 상태가 반영되게 한다.
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.GET_USER_INFO });
 
       // creditGap = 총취득학점 - 과목 학점 합. 0이면 정합성 정상이므로 바로 졸업 판정으로 이동한다.
       const { creditGap } = data.result;

--- a/src/pages/authCallback.tsx
+++ b/src/pages/authCallback.tsx
@@ -1,6 +1,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import { toast } from 'sonner';
 
 import { getUserInfo } from '@/apis/user/user';
 import Loading from '@/components/common/loading';
@@ -21,6 +22,14 @@ export default function AuthCallback() {
   useEffect(() => {
     if (handledRef.current) return;
     handledRef.current = true;
+
+    // 백엔드가 로그인 실패 시 ?error=... 를 붙여 리다이렉트한다. (예: error=login_failed)
+    // 이 경우 실패를 토스트로 안내하고 로그인 화면으로 되돌린다.
+    if (searchParams.get('error')) {
+      toast.error('로그인에 실패했어요. 다시 시도해주세요.');
+      navigate('/login', { replace: true });
+      return;
+    }
 
     const accessToken = searchParams.get('accessToken');
     // 토큰이 없으면 비정상 진입이므로 로그인 화면으로 되돌린다.

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -4,7 +4,35 @@ import { create } from 'zustand';
 // refreshToken은 HttpOnly 쿠키라 JS가 존재 여부를 알 수 없으므로,
 // 로그인/토큰 발급 시 이 플래그를 남겨 두고 "쿠키가 있을 법한 사용자"인지 추정하는 데 쓴다.
 // (토큰 값 자체는 저장하지 않는다. 단순 불리언 힌트)
-export const SESSION_HINT_KEY = 'hasSession';
+const SESSION_HINT_KEY = 'hasSession';
+
+// localStorage 접근은 일부 환경(사파리 비공개 모드, 스토리지 차단/용량 초과 등)에서 예외를 던질 수 있다.
+// 세션 힌트는 보조 수단일 뿐이라, 접근 실패가 인증 상태나 인터셉터 흐름을 끊지 않도록 모두 안전하게 감싼다.
+const setSessionHint = () => {
+  try {
+    localStorage.setItem(SESSION_HINT_KEY, '1');
+  } catch {
+    // 쓰기 실패는 무시한다.
+  }
+};
+
+const clearSessionHint = () => {
+  try {
+    localStorage.removeItem(SESSION_HINT_KEY);
+  } catch {
+    // 삭제 실패는 무시한다.
+  }
+};
+
+// 세션 힌트(로그인 이력) 존재 여부를 안전하게 읽는다.
+// 스토리지 접근 자체가 막힌 경우엔 refresh 기회를 막지 않도록 true로 간주한다. (fail-open)
+export const hasSessionHint = (): boolean => {
+  try {
+    return !!localStorage.getItem(SESSION_HINT_KEY);
+  } catch {
+    return true;
+  }
+};
 
 interface IAuthState {
   accessToken: string | null;
@@ -19,12 +47,12 @@ export const useAuthStore = create<IAuthState & IAuthActions>((set) => ({
   accessToken: null,
   // 토큰을 받으면(로그인/재발급) 세션 힌트를 남긴다.
   setAccessToken: (token) => {
-    localStorage.setItem(SESSION_HINT_KEY, '1');
+    setSessionHint();
     set({ accessToken: token });
   },
   // 인증을 비우면(로그아웃/refresh 실패) 세션 힌트도 제거한다.
   clearAuth: () => {
-    localStorage.removeItem(SESSION_HINT_KEY);
+    clearSessionHint();
     set({ accessToken: null });
   },
 }));

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,5 +1,11 @@
 import { create } from 'zustand';
 
+// "이 브라우저에서 로그인한 적이 있는지"를 나타내는 세션 힌트 키.
+// refreshToken은 HttpOnly 쿠키라 JS가 존재 여부를 알 수 없으므로,
+// 로그인/토큰 발급 시 이 플래그를 남겨 두고 "쿠키가 있을 법한 사용자"인지 추정하는 데 쓴다.
+// (토큰 값 자체는 저장하지 않는다. 단순 불리언 힌트)
+export const SESSION_HINT_KEY = 'hasSession';
+
 interface IAuthState {
   accessToken: string | null;
 }
@@ -11,6 +17,14 @@ interface IAuthActions {
 
 export const useAuthStore = create<IAuthState & IAuthActions>((set) => ({
   accessToken: null,
-  setAccessToken: (token) => set({ accessToken: token }),
-  clearAuth: () => set({ accessToken: null }),
+  // 토큰을 받으면(로그인/재발급) 세션 힌트를 남긴다.
+  setAccessToken: (token) => {
+    localStorage.setItem(SESSION_HINT_KEY, '1');
+    set({ accessToken: token });
+  },
+  // 인증을 비우면(로그아웃/refresh 실패) 세션 힌트도 제거한다.
+  clearAuth: () => {
+    localStorage.removeItem(SESSION_HINT_KEY);
+    set({ accessToken: null });
+  },
 }));


### PR DESCRIPTION
## 📋 작업 내용
- 인증·공통 응답 명세 정합성 보강

## 🎯 관련 이슈
- closes #39 

## 📝 변경 사항
- OAuth 콜백 실패(`?error=`) 시 토스트 안내 후 `/login` 이동 (기존: 조용히 이동)
- 성적표 업로드 성공 시 `GET_USER_INFO` 무효화 — 서버 자동 본인 인증(identityVerified) 갱신 반영
- 미인증 사용자 refresh 왕복 제거 — 로그인 이력 세션 힌트(localStorage 불리언)가 없으면 refresh 스킵
- `useCoreQuery` 재시도를 401 한정 → 4xx 전체 즉시 중단으로 일반화 (5xx·네트워크만 재시도)

## 📸 스크린샷 (선택사항)
<!--
필요한 경우 스크린샷 첨부
-->
