### PR TITLE
[Refactor] 온보딩 입력 유효성 검사

### DIFF
--- a/src/components/onBoardingModal.tsx
+++ b/src/components/onBoardingModal.tsx
@@ -5,19 +5,68 @@ import TextField from '@/components/common/textField';
 import useOnboarding from '@/hooks/auth/useOnboarding';
 import { useModalStore } from '@/stores/modalStore';
 
+// 클라이언트 입력 검증 (서버 규칙과 동일하게 맞춘다)
+// 이름: 필수, 5자 이하 / 학번: 필수, 숫자 10자리
+const validateName = (value: string): string => {
+  if (!value.trim()) return '*이름을 입력해주세요.';
+  if (value.length > 5) return '*이름은 5자 이하로 입력해주세요.';
+  return '';
+};
+
+const validateStudentId = (value: string): string => {
+  if (!value) return '*학번을 입력해주세요.';
+  if (!/^\d{10}$/.test(value)) return '*학번은 숫자 10자리로 입력해주세요.';
+  return '';
+};
+
 export default function OnBoardingModal() {
   const { type, closeModal } = useModalStore();
   const { mutate: submitOnboarding, isPending } = useOnboarding();
   const [name, setName] = useState('');
   const [studentId, setStudentId] = useState('');
+  // 필드별 에러 메시지와, 한 번이라도 포커스가 빠진(=검증을 시작할) 필드 여부
+  const [nameError, setNameError] = useState('');
+  const [studentIdError, setStudentIdError] = useState('');
+  const [touched, setTouched] = useState({ name: false, studentId: false });
   const [agreedPrivacy, setAgreedPrivacy] = useState(false);
   const [agreedTerms, setAgreedTerms] = useState(false);
   const [agreedAge, setAgreedAge] = useState(false);
 
   if (type !== 'onboarding') return null;
 
+  // 이름 입력 변경: 이미 검증이 시작된 필드면 입력하는 즉시 에러를 다시 계산해 갱신한다.
+  const handleNameChange = (value: string) => {
+    setName(value);
+    if (touched.name) setNameError(validateName(value));
+  };
+
+  // 학번 입력 변경: 동일하게 검증이 시작된 경우에만 실시간 재검증한다.
+  const handleStudentIdChange = (value: string) => {
+    setStudentId(value);
+    if (touched.studentId) setStudentIdError(validateStudentId(value));
+  };
+
+  // 포커스가 빠지는 순간 검증을 시작(touched=true)하고 에러를 표시한다.
+  const handleNameBlur = () => {
+    setTouched((prev) => ({ ...prev, name: true }));
+    setNameError(validateName(name));
+  };
+
+  const handleStudentIdBlur = () => {
+    setTouched((prev) => ({ ...prev, studentId: true }));
+    setStudentIdError(validateStudentId(studentId));
+  };
+
   // 온보딩 정보 저장. 성공 시 홈 이동은 useOnboarding이 처리하고, 여기서는 모달만 닫는다.
   const handleSubmit = () => {
+    // 제출 시점에 두 필드를 모두 검증하고, 하나라도 어긋나면 전송하지 않는다.
+    const nextNameError = validateName(name);
+    const nextStudentIdError = validateStudentId(studentId);
+    setNameError(nextNameError);
+    setStudentIdError(nextStudentIdError);
+    setTouched({ name: true, studentId: true });
+    if (nextNameError || nextStudentIdError) return;
+
     submitOnboarding({ studentId, name }, { onSuccess: () => closeModal() });
   };
 
@@ -31,11 +80,24 @@ export default function OnBoardingModal() {
         <div className="flex flex-col gap-3">
           <label className="flex flex-col gap-1">
             <span className="text-body-m">이름</span>
-            <TextField placeholder="김동국" value={name} onChange={(e) => setName(e.target.value)} />
+            <TextField
+              placeholder="김동국"
+              value={name}
+              onChange={(e) => handleNameChange(e.target.value)}
+              onBlur={handleNameBlur}
+              error={nameError}
+            />
           </label>
           <label className="flex flex-col gap-1">
             <span className="text-body-m">학번</span>
-            <TextField placeholder="2023123456" value={studentId} onChange={(e) => setStudentId(e.target.value)} />
+            <TextField
+              placeholder="2023123456"
+              value={studentId}
+              inputMode="numeric"
+              onChange={(e) => handleStudentIdChange(e.target.value)}
+              onBlur={handleStudentIdBlur}
+              error={studentIdError}
+            />
           </label>
         </div>
 

--- a/src/components/onBoardingModal.tsx
+++ b/src/components/onBoardingModal.tsx
@@ -47,27 +47,32 @@ export default function OnBoardingModal() {
   };
 
   // 포커스가 빠지는 순간 검증을 시작(touched=true)하고 에러를 표시한다.
-  const handleNameBlur = () => {
+  // 상태(name/studentId) 대신 이벤트의 최신 값을 직접 받아 stale 값으로 검증되는 것을 방지한다.
+  const handleNameBlur = (value: string) => {
     setTouched((prev) => ({ ...prev, name: true }));
-    setNameError(validateName(name));
+    setNameError(validateName(value));
   };
 
-  const handleStudentIdBlur = () => {
+  const handleStudentIdBlur = (value: string) => {
     setTouched((prev) => ({ ...prev, studentId: true }));
-    setStudentIdError(validateStudentId(studentId));
+    setStudentIdError(validateStudentId(value));
   };
 
   // 온보딩 정보 저장. 성공 시 홈 이동은 useOnboarding이 처리하고, 여기서는 모달만 닫는다.
   const handleSubmit = () => {
+    // 앞뒤 공백이 그대로 서버에 저장되지 않도록 trim 후 검증·전송한다.
+    const trimmedName = name.trim();
+    const trimmedStudentId = studentId.trim();
+
     // 제출 시점에 두 필드를 모두 검증하고, 하나라도 어긋나면 전송하지 않는다.
-    const nextNameError = validateName(name);
-    const nextStudentIdError = validateStudentId(studentId);
+    const nextNameError = validateName(trimmedName);
+    const nextStudentIdError = validateStudentId(trimmedStudentId);
     setNameError(nextNameError);
     setStudentIdError(nextStudentIdError);
     setTouched({ name: true, studentId: true });
     if (nextNameError || nextStudentIdError) return;
 
-    submitOnboarding({ studentId, name }, { onSuccess: () => closeModal() });
+    submitOnboarding({ studentId: trimmedStudentId, name: trimmedName }, { onSuccess: () => closeModal() });
   };
 
   return (
@@ -84,7 +89,7 @@ export default function OnBoardingModal() {
               placeholder="김동국"
               value={name}
               onChange={(e) => handleNameChange(e.target.value)}
-              onBlur={handleNameBlur}
+              onBlur={(e) => handleNameBlur(e.target.value)}
               error={nameError}
             />
           </label>
@@ -95,7 +100,7 @@ export default function OnBoardingModal() {
               value={studentId}
               inputMode="numeric"
               onChange={(e) => handleStudentIdChange(e.target.value)}
-              onBlur={handleStudentIdBlur}
+              onBlur={(e) => handleStudentIdBlur(e.target.value)}
               error={studentIdError}
             />
           </label>

--- a/src/hooks/auth/useOnboarding.ts
+++ b/src/hooks/auth/useOnboarding.ts
@@ -1,21 +1,45 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
 
 import { postOnboarding } from '@/apis/auth/auth';
 import { QUERY_KEYS } from '@/constants/querykeys/queryKeys';
 import { useCoreMutation } from '@/hooks/customQuery';
+import { useModalStore } from '@/stores/modalStore';
 import type { TPostOnboardingRequest } from '@/types/auth/TPostOnboarding';
+import type { TResponseError } from '@/types/common';
 
 // 온보딩 정보 저장 훅
 // 성공 시 사용자 정보 캐시를 무효화하고(온보딩 완료 반영) 홈으로 이동시킨다.
+// onError를 직접 제공하므로(either/or) 공용 기본 토스트 대신 코드별로 분기 처리한다.
 export default function useOnboarding() {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
+  const closeModal = useModalStore((state) => state.closeModal);
 
   return useCoreMutation((body: TPostOnboardingRequest) => postOnboarding(body), {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.GET_USER_INFO });
       navigate('/');
+    },
+    onError: (error: TResponseError) => {
+      const code = error.response?.data?.code;
+
+      // 이미 온보딩 완료된 회원(다른 탭에서 먼저 완료한 레이스 등): 입력을 저장하지 않고 모달을 닫은 뒤 홈으로 보낸다.
+      if (code === 'USER409_1') {
+        closeModal();
+        navigate('/');
+        return;
+      }
+
+      // 학번 중복은 제출 시점에만 알 수 있으므로 토스트로 안내한다.
+      if (code === 'USER409_2') {
+        toast.error('이미 가입한 학번입니다.');
+        return;
+      }
+
+      // 그 외(회원 없음 등 예기치 못한 경우)는 서버 메시지를 토스트로 안내한다.
+      toast.error(error.response?.data?.message ?? '온보딩 처리 중 오류가 발생했어요.');
     },
   });
 }


### PR DESCRIPTION
## 📋 작업 내용
- 온보딩 폼에 클라이언트 입력 검증과 제출 시 서버 에러 분기 처리를 추가

## 🎯 관련 이슈
- closes #41

## 📝 변경 사항
- 이름(필수·5자 이하)·학번(숫자 10자리) 클라이언트 검증 추가
- blur 시 검증 시작, 입력 중 실시간 에러 갱신, 제출 시 재검증 후 전송
- 학번 중복(USER409_2) 토스트, 이미 온보딩(USER409_1) 시 모달 닫고 홈 이동
- 공용 TextField의 기존 error 표시 활용 (인라인 빨간 글씨)

## 📸 스크린샷 (선택사항)
<!--
필요한 경우 스크린샷 첨부
-->
