### PR TITLE
[Feat] 사용자 학업 정보 조회 API 연동 구현

### DIFF
--- a/src/apis/report/report.ts
+++ b/src/apis/report/report.ts
@@ -1,5 +1,12 @@
 import axiosInstance from '@/apis/axiosInstance';
+import type { TGetUserReportsResponse } from '@/types/report/TGetUserReports';
 import type { TPutTranscriptResponse } from '@/types/report/TPutTranscript';
+
+// 성적표(학업 리포트) 조회. 성적표가 없으면 404(TRANSCRIPT404_1)를 반환한다.
+export const getUserReports = async () => {
+  const { data } = await axiosInstance.get<TGetUserReportsResponse>('/api/users/me/reports');
+  return data.result;
+};
 
 // 성적표 PDF 업로드 (multipart/form-data, 파트명 'file').
 // 서버가 PDF를 파싱해 학업 정보를 저장하며, 기존 성적표가 있으면 soft-delete 후 새로 생성한다.

--- a/src/hooks/report/useUserReports.ts
+++ b/src/hooks/report/useUserReports.ts
@@ -1,0 +1,10 @@
+import { getUserReports } from '@/apis/report/report';
+import { QUERY_KEYS } from '@/constants/querykeys/queryKeys';
+import { useCoreQuery } from '@/hooks/customQuery';
+
+// 성적표(학업 리포트) 조회 훅.
+// 라우트 게이트와 학업 정보 화면에서 함께 쓰이므로 query 상태 전체를 반환한다.
+// 성적표가 없으면 404(TRANSCRIPT404_1)로 isError가 된다. (호출부에서 업로드 유도로 분기)
+export default function useUserReports() {
+  return useCoreQuery(QUERY_KEYS.GET_USER_REPORTS, () => getUserReports());
+}

--- a/src/pages/academicRecords.tsx
+++ b/src/pages/academicRecords.tsx
@@ -1,10 +1,14 @@
 import { useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Navigate, useNavigate } from 'react-router-dom';
 
 import Edit from '@/assets/icons/edit.svg?react';
 import Button from '@/components/common/button';
+import Loading from '@/components/common/loading';
 import TextField from '@/components/common/textField';
+import useUserReports from '@/hooks/report/useUserReports';
 import useInView from '@/hooks/useInView';
+import NotFound from '@/pages/notFound';
+import type { TTranscriptRecord } from '@/types/report/TGetUserReports';
 
 interface ICourse {
   category: string;
@@ -20,100 +24,19 @@ interface IAddedCourse extends ICourse {
   id: number;
 }
 
-interface ISemester {
-  semester: string;
-  courses: ICourse[];
-}
-
-// TODO: API 연동 시 교체
-const MOCK_BASIC_INFO = {
-  curriculumYear: '2023',
-  program: '주간',
-  college: '소프트웨어융합대학',
-};
-
-const BASIC_INFO_ITEMS = [
-  { label: '교육과정 적용년도', value: MOCK_BASIC_INFO.curriculumYear },
-  { label: '과정', value: MOCK_BASIC_INFO.program },
-  { label: '단과대학', value: MOCK_BASIC_INFO.college },
-] as const;
-
-// TODO: API 연동 시 교체
-const MOCK_SEMESTERS: ISemester[] = [
-  {
-    semester: '2023-1',
-    courses: [
-      {
-        category: '공통교양',
-        courseCode: 'GED1001',
-        courseName: '글쓰기',
-        credits: 3,
-        grade: 'A+',
-        area: '사고와표현',
-        retake: 'O',
-      },
-      {
-        category: '공통교양',
-        courseCode: 'GED1002',
-        courseName: '채플',
-        credits: 1,
-        grade: 'P',
-        area: '채플',
-        retake: 'X',
-      },
-      {
-        category: '학문기초',
-        courseCode: 'CSE1001',
-        courseName: '컴퓨터공학입문',
-        credits: 3,
-        grade: 'A0',
-        area: '1전공',
-        retake: 'X',
-      },
-      {
-        category: '전공필수',
-        courseCode: 'CSE2001',
-        courseName: '자료구조',
-        credits: 3,
-        grade: 'B+',
-        area: '1전공',
-        retake: 'X',
-      },
-    ],
-  },
-  {
-    semester: '2023-2',
-    courses: [
-      {
-        category: '전공필수',
-        courseCode: 'CSE2002',
-        courseName: '운영체제',
-        credits: 3,
-        grade: 'A+',
-        area: '1전공',
-        retake: 'X',
-      },
-      {
-        category: '전공선택',
-        courseCode: 'CSE3010',
-        courseName: '데이터베이스',
-        credits: 3,
-        grade: 'A0',
-        area: '1전공',
-        retake: 'X',
-      },
-      {
-        category: '일반교양',
-        courseCode: 'GED2001',
-        courseName: '철학입문',
-        credits: 3,
-        grade: 'B+',
-        area: '인문',
-        retake: 'X',
-      },
-    ],
-  },
-];
+// API 수강 이력(TTranscriptRecord)을 화면 표시용(ICourse + id) 형태로 변환한다.
+// 기존 수강 표와 수동 추가 행이 공유하는 ICourse 구조에 맞춘다.
+// (이수영역 null → '-', 재수강 boolean → 'O'/'X')
+const toDisplayCourse = (record: TTranscriptRecord): IAddedCourse => ({
+  id: record.id,
+  category: record.courseType,
+  courseCode: record.courseCode,
+  courseName: record.courseName,
+  credits: record.credits,
+  grade: record.grade,
+  area: record.areaName ?? '-',
+  retake: record.retake ? 'O' : 'X',
+});
 
 type TCourseField = keyof ICourse;
 
@@ -144,6 +67,7 @@ export default function AcademicRecords() {
   const [ref, isInView] = useInView();
   const [addedCourses, setAddedCourses] = useState<Record<string, IAddedCourse[]>>({});
   const nextId = useRef(0);
+  const { data, isPending, isError, error } = useUserReports();
 
   const hasNewCourses = Object.values(addedCourses).some((courses) => courses.length > 0);
 
@@ -169,6 +93,29 @@ export default function AcademicRecords() {
     }));
   };
 
+  // 성적표 조회 상태 처리: 로딩 → 공용 Loading, 미업로드(404) → 업로드 유도, 그 외 에러 → NotFound
+  if (isPending) {
+    return <Loading />;
+  }
+  if (isError) {
+    if (error.response?.status === 404) {
+      return <Navigate to="/upload" replace />;
+    }
+    return <NotFound />;
+  }
+
+  const { meta, courses } = data;
+
+  // 상단 기본 정보 항목. 부전공/복수전공은 값이 있을 때만(null이면 숨김) 한 줄씩 추가한다.
+  const basicInfoItems: { label: string; value: string | number }[] = [
+    { label: '교육과정 적용년도', value: meta.admissionYear },
+    { label: '학과', value: meta.department },
+  ];
+  if (meta.subMajor1) basicInfoItems.push({ label: '부전공1', value: meta.subMajor1 });
+  if (meta.subMajor2) basicInfoItems.push({ label: '부전공2', value: meta.subMajor2 });
+  if (meta.dualMajor1) basicInfoItems.push({ label: '복수전공1', value: meta.dualMajor1 });
+  if (meta.dualMajor2) basicInfoItems.push({ label: '복수전공2', value: meta.dualMajor2 });
+
   return (
     <div
       ref={ref}
@@ -183,7 +130,7 @@ export default function AcademicRecords() {
       <div className={sectionStyles}>
         <p className="text-heading-3 text-coolgray-90">기본 정보</p>
         <div className="flex w-full flex-col gap-3 px-20">
-          {BASIC_INFO_ITEMS.map(({ label, value }) => (
+          {basicInfoItems.map(({ label, value }) => (
             <div key={label} className="flex justify-between">
               <span className="text-heading-5 text-coolgray-90">{label}</span>
               <span className="text-body-l text-coolgray-90">{value}</span>
@@ -193,7 +140,7 @@ export default function AcademicRecords() {
       </div>
 
       {/* 학기별 수강 내역 */}
-      {MOCK_SEMESTERS.map((semesterData) => (
+      {courses.map((semesterData) => (
         <div key={semesterData.semester} className={sectionStyles}>
           <p className="text-heading-3 text-coolgray-90">{semesterData.semester}</p>
           <div className="w-full">
@@ -207,9 +154,9 @@ export default function AcademicRecords() {
               <div className="w-[4%]" />
             </div>
 
-            {/* 기존 수강 행 */}
-            {semesterData.courses.map((course) => (
-              <div key={course.courseCode} className="flex w-full items-center border-b border-coolgray-10 py-3">
+            {/* 기존 수강 행 (API 데이터) */}
+            {semesterData.records.map(toDisplayCourse).map((course) => (
+              <div key={course.id} className="flex w-full items-center border-b border-coolgray-10 py-3">
                 {COLUMNS.map((col) => (
                   <div key={col.key} className={`${col.width} text-center text-body-l text-coolgray-90`}>
                     {col.key === 'retake' ? (

--- a/src/pages/graduation.tsx
+++ b/src/pages/graduation.tsx
@@ -278,7 +278,7 @@ export default function Graduation() {
 
       {/* 버튼 */}
       <div ref={buttonRef} className={`flex gap-4 justify-center ${buttonInView ? 'animate-fade-in-up' : 'opacity-0'}`}>
-        <Button variant="outlined" className="w-60" onClick={() => navigate('/academic-records')}>
+        <Button variant="outlined" className="w-60" onClick={() => navigate('/my-page/academic-records')}>
           내 학업 정보 수정
         </Button>
         <Button className="w-60" onClick={() => navigate('/curriculum')}>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -13,6 +13,7 @@ import OnBoarding from '@/pages/onBoarding';
 import Profile from '@/pages/profile';
 import UploadPage from '@/pages/uploadPage';
 import ProtectedRoute from '@/routes/protectedRoute';
+import ReportGate from '@/routes/reportGate';
 
 export const router = createBrowserRouter([
   // 인증 없이 접근 가능한 라우트 (로그인, OAuth 콜백)
@@ -37,7 +38,11 @@ export const router = createBrowserRouter([
             ],
           },
           { path: 'curriculum', element: <Curriculum /> },
-          { path: 'graduation', element: <Graduation /> },
+          // 졸업 판정은 성적표가 있어야 의미가 있으므로 리포트 게이트를 한 번 더 통과시킨다.
+          {
+            element: <ReportGate />,
+            children: [{ path: 'graduation', element: <Graduation /> }],
+          },
           { path: 'onboarding', element: <OnBoarding /> },
           { path: 'upload', element: <UploadPage /> },
         ],

--- a/src/routes/reportGate.tsx
+++ b/src/routes/reportGate.tsx
@@ -1,0 +1,30 @@
+import { Navigate, Outlet } from 'react-router-dom';
+
+import Loading from '@/components/common/loading';
+import useUserReports from '@/hooks/report/useUserReports';
+import NotFound from '@/pages/notFound';
+
+// 리포트(성적표) 존재 게이트.
+// ProtectedRoute(인증·온보딩) 통과 후, 성적표 유무로 한 번 더 분기한다.
+// - 조회 중: 로딩
+// - 성적표 없음(404 TRANSCRIPT404_1): 업로드 화면으로 유도
+// - 그 외 에러: NotFound
+// - 성적표 있음: 통과(졸업 판정 등 렌더)
+export default function ReportGate() {
+  const { isPending, isError, error } = useUserReports();
+
+  if (isPending) {
+    return <Loading />;
+  }
+
+  if (isError) {
+    // 미업로드(404)는 정상 흐름이므로 업로드로 보낸다.
+    if (error.response?.status === 404) {
+      return <Navigate to="/upload" replace />;
+    }
+    // 예기치 못한 오류는 NotFound로 처리한다.
+    return <NotFound />;
+  }
+
+  return <Outlet />;
+}

--- a/src/types/report/TGetUserReports.ts
+++ b/src/types/report/TGetUserReports.ts
@@ -1,0 +1,43 @@
+import type { TCommonResponse } from '@/types/common';
+
+// GET /api/users/me/reports 응답
+// 성적표(학업 리포트) 메타 정보 + 학기별 수강 이력(학기 오름차순 그룹)
+
+// 상단 메타 정보
+export type TReportMeta = {
+  admissionYear: number; // 입학년도
+  department: string; // 전공 학과명
+  subMajor1: string | null; // 제1부전공 학과명 (없으면 null)
+  subMajor2: string | null; // 제2부전공 학과명 (없으면 null)
+  dualMajor1: string | null; // 제1복수전공 학과명 (없으면 null)
+  dualMajor2: string | null; // 제2복수전공 학과명 (없으면 null)
+  academicStatus: string; // 학적 상태 (예: 재학)
+  totalCredits: number; // 총취득학점
+  gpa: number; // 평점 평균
+  completedSemesters: number; // 이수 학기 수
+};
+
+// 개별 수강 이력
+export type TTranscriptRecord = {
+  id: number;
+  courseCode: string; // 학수번호
+  courseName: string; // 교과목명
+  credits: number; // 학점
+  courseType: string; // 이수 구분 (PDF 원시 문자열: 전공/공교/일교 등)
+  areaName: string | null; // 이수 영역명 (없으면 null)
+  grade: string; // 성적 (A+, A0, ... P, NP)
+  retake: boolean; // 재수강 여부
+};
+
+// 학기별 수강 이력 그룹
+export type TSemesterCourses = {
+  semester: string; // 학기 (예: 2023-1, 2023-여름)
+  records: TTranscriptRecord[];
+};
+
+export type TGetUserReportsResult = {
+  meta: TReportMeta;
+  courses: TSemesterCourses[];
+};
+
+export type TGetUserReportsResponse = TCommonResponse<TGetUserReportsResult>;


### PR DESCRIPTION
## 📋 작업 내용
- 사용자 학업 정보 조회(GET /api/users/me/reports) 연동, 졸업 판정 진입 라우트 게이트, 학업 정보 화면 연결

## 🎯 관련 이슈
- closes #43

## 📝 변경 사항
- getUserReports API·useUserReports 훅·응답 타입 추가
- /graduation 리포트 게이트 추가 (리포트 없으면 /upload, 그 외 에러 NotFound)
- academic-records 메타 정보·학기별 수강 내역 API 연동 (로딩/404/에러 처리)
- graduation '내 학업 정보 수정' 버튼 경로(/my-page/academic-records) 수정


## 📸 스크린샷 (선택사항)
<!--
필요한 경우 스크린샷 첨부
-->
