### PR TITLE
[Feat] 학업 리포트 조회 API 연동 구현

### DIFF
--- a/src/apis/report/report.ts
+++ b/src/apis/report/report.ts
@@ -1,10 +1,25 @@
 import axiosInstance from '@/apis/axiosInstance';
+import type { TCourseName } from '@/types/course';
+import type { TGetReportDetailResponse } from '@/types/report/TGetReportDetail';
+import type { TGetReportSummaryResponse } from '@/types/report/TGetReportSummary';
 import type { TGetUserReportsResponse } from '@/types/report/TGetUserReports';
 import type { TPutTranscriptResponse } from '@/types/report/TPutTranscript';
 
 // 성적표(학업 리포트) 조회. 성적표가 없으면 404(TRANSCRIPT404_1)를 반환한다.
 export const getUserReports = async () => {
   const { data } = await axiosInstance.get<TGetUserReportsResponse>('/api/users/me/reports');
+  return data.result;
+};
+
+// 졸업 달성률 요약 조회. 리포트 없음(404 GRADUATION404_1)·요건 없음(404 GRADUATION404_2) 가능.
+export const getReportSummary = async () => {
+  const { data } = await axiosInstance.get<TGetReportSummaryResponse>('/api/reports/summary');
+  return data.result;
+};
+
+// courseType별 영역 상세 조회. 잘못된 courseType은 400(COMMON400_1).
+export const getReportDetail = async (courseType: TCourseName) => {
+  const { data } = await axiosInstance.get<TGetReportDetailResponse>('/api/reports', { params: { courseType } });
   return data.result;
 };
 

--- a/src/components/courseTabView.tsx
+++ b/src/components/courseTabView.tsx
@@ -2,43 +2,32 @@ import { useState } from 'react';
 
 import AreaDetailCard from '@/components/areaDetailCard';
 import type { TChipVariant } from '@/components/chip';
-import { COURSE_LABEL, COURSE_NAMES, type TCourseName } from '@/types/course';
+import useReportDetail from '@/hooks/report/useReportDetail';
+import { COURSE_LABEL, type TCourseName } from '@/types/course';
+import type { TReportItemStatus } from '@/types/report/TGetReportDetail';
 
-interface ISubject {
-  name: string;
-  credits: number;
-  chipVariant: TChipVariant;
-  details?: string[];
-}
-
-interface ICourseTabData {
-  areaDetails: {
-    areaName: string;
-    chipVariant: TChipVariant;
-    requiredCredits: number;
-    completedCredits: number;
-    subjects: ISubject[];
-  }[];
-  unsatisfiedReasons: string[];
-  completedCredits: number;
-  targetCredits: number;
-  remainingCredits: number;
-}
+// 과목 이수 상태 → 칩 variant 매핑
+const STATUS_TO_CHIP: Record<TReportItemStatus, TChipVariant> = {
+  SATISFIED: 'satisfied', // 필수 이수 → 충족
+  UNSATISFIED: 'unsatisfied', // 필수 미이수 → 불충족
+  OPTIONAL: 'selected', // 선택 이수 → 선택
+};
 
 interface ICourseTabViewProps {
-  data: Partial<Record<TCourseName, ICourseTabData>>;
+  // summary의 areaOverviews에서 받은, 이 회원에게 적용되는 영역 탭 목록
+  courseTypes: TCourseName[];
 }
 
-export default function CourseTabView({ data }: ICourseTabViewProps) {
-  const availableCourses = COURSE_NAMES.filter((course) => course in data);
-  const [activeTab, setActiveTab] = useState<TCourseName>(availableCourses[0] ?? 'COMMON_GENERAL');
-  const tabData = data[activeTab];
+export default function CourseTabView({ courseTypes }: ICourseTabViewProps) {
+  const [activeTab, setActiveTab] = useState<TCourseName>(courseTypes[0] ?? 'COMMON_GENERAL');
+  // 활성 탭의 courseType으로만 상세를 조회한다(지연 로딩, 탭별 캐시).
+  const { data, isPending, isError } = useReportDetail(activeTab);
 
   return (
     <div className="flex flex-col gap-7 px-8 py-4">
       <div className="w-full border-b border-coolgray-20">
         <div className="flex justify-center gap-8">
-          {availableCourses.map((course) => (
+          {courseTypes.map((course) => (
             <button
               key={course}
               type="button"
@@ -53,17 +42,26 @@ export default function CourseTabView({ data }: ICourseTabViewProps) {
         </div>
       </div>
 
-      {tabData && (
+      {isPending ? (
+        <p className="py-10 text-center text-body-l text-coolgray-60">불러오는 중...</p>
+      ) : isError || !data ? (
+        <p className="py-10 text-center text-body-l text-coolgray-60">정보를 불러오지 못했어요.</p>
+      ) : (
         <div key={activeTab} className="flex flex-col gap-7 animate-fade-in">
           <div className="flex gap-3 overflow-x-auto">
-            {tabData.areaDetails.map((area) => (
+            {data.areaDetails.map((area) => (
               <AreaDetailCard
                 key={area.areaName}
                 areaName={area.areaName}
-                chipVariant={area.chipVariant}
-                requiredCredits={area.requiredCredits}
-                completedCredits={area.completedCredits}
-                subjects={area.subjects}
+                chipVariant={area.satisfied ? 'satisfied' : 'unsatisfied'}
+                requiredCredits={area.targetCredits}
+                completedCredits={area.earnedCredits}
+                subjects={area.items.map((item) => ({
+                  name: item.title,
+                  credits: item.credit,
+                  chipVariant: STATUS_TO_CHIP[item.status],
+                  details: item.detail ?? undefined,
+                }))}
               />
             ))}
           </div>
@@ -71,8 +69,8 @@ export default function CourseTabView({ data }: ICourseTabViewProps) {
           <div className="flex gap-10">
             <div className="flex-1 border border-coolgray-20 p-4 flex flex-col gap-2">
               <span className="text-heading-5 text-coolgray-90">미충족 사유</span>
-              {tabData.unsatisfiedReasons.length > 0 ? (
-                tabData.unsatisfiedReasons.map((reason) => (
+              {data.unsatisfiedReasons.length > 0 ? (
+                data.unsatisfiedReasons.map((reason) => (
                   <span key={reason} className="text-button-m text-alert">
                     {reason}
                   </span>
@@ -86,15 +84,15 @@ export default function CourseTabView({ data }: ICourseTabViewProps) {
               <span className="text-heading-5 text-coolgray-90">영역 이수 현황</span>
               <div className="flex justify-between text-heading-6 text-coolgray-90">
                 <span>이수 학점</span>
-                <span>{tabData.completedCredits}학점</span>
+                <span>{data.creditStatus.earnedCredits}학점</span>
               </div>
               <div className="flex justify-between text-heading-6 text-coolgray-90">
                 <span>목표 이수 학점</span>
-                <span>{tabData.targetCredits}학점</span>
+                <span>{data.creditStatus.targetCredits}학점</span>
               </div>
               <div className="flex justify-between text-heading-6 text-coolgray-90">
                 <span>잔여 학점</span>
-                <span className="text-primary-60">{tabData.remainingCredits}학점</span>
+                <span className="text-primary-60">{data.creditStatus.remainingCredits}학점</span>
               </div>
             </div>
           </div>

--- a/src/hooks/report/useReportDetail.ts
+++ b/src/hooks/report/useReportDetail.ts
@@ -1,0 +1,11 @@
+import { getReportDetail } from '@/apis/report/report';
+import { QUERY_KEYS } from '@/constants/querykeys/queryKeys';
+import { useCoreQuery } from '@/hooks/customQuery';
+import type { TCourseName } from '@/types/course';
+
+// courseType별 영역 상세 조회 훅.
+// 탭뷰에서 활성 탭의 courseType으로만 호출되어, 활성 탭 데이터만 조회한다(지연 로딩).
+// courseType이 queryKey에 포함되므로 탭별로 캐시되어 재방문 시 즉시 표시된다.
+export default function useReportDetail(courseType: TCourseName) {
+  return useCoreQuery(QUERY_KEYS.GET_REPORT_BY_COURSE_TYPE(courseType), () => getReportDetail(courseType));
+}

--- a/src/hooks/report/useReportSummary.ts
+++ b/src/hooks/report/useReportSummary.ts
@@ -1,0 +1,9 @@
+import { getReportSummary } from '@/apis/report/report';
+import { QUERY_KEYS } from '@/constants/querykeys/queryKeys';
+import { useCoreQuery } from '@/hooks/customQuery';
+
+// 졸업 달성률 요약 조회 훅.
+// 리포트 없음(GRADUATION404_1)·요건 없음(GRADUATION404_2)이면 isError가 된다. (호출부에서 분기)
+export default function useReportSummary() {
+  return useCoreQuery(QUERY_KEYS.GET_REPORT_SUMMARY, () => getReportSummary());
+}

--- a/src/pages/graduation.tsx
+++ b/src/pages/graduation.tsx
@@ -1,198 +1,70 @@
-import { useNavigate } from 'react-router-dom';
+import { useEffect } from 'react';
+import { Navigate, useNavigate } from 'react-router-dom';
 
 import Chart from '@/assets/icons/chart.svg?react';
+import Warning from '@/assets/icons/warning.svg?react';
 import Button from '@/components/common/button';
+import Loading from '@/components/common/loading';
 import CourseSummaryCard from '@/components/courseSummaryCard';
 import CourseTabView from '@/components/courseTabView';
 import ProgressBar from '@/components/progressBar';
+import { TRANSCRIPT_ERROR_MODAL } from '@/constants/report/transcriptErrorModals';
+import useReportSummary from '@/hooks/report/useReportSummary';
 import useInView from '@/hooks/useInView';
-import type { TCourseName } from '@/types/course';
+import NotFound from '@/pages/notFound';
+import { useModalStore } from '@/stores/modalStore';
 
 export default function Graduation() {
-  // TODO: API 연동 시 교체
-  const progress = 85;
-  const completedCredits = 120;
-  const targetCredits = 140;
-  const remainingCredits = 20;
-  const gpa = 3.85;
-  const graduationStatus = 'FAIL' as 'PASS' | 'FAIL';
-
-  const courseSummary: {
-    courseName: TCourseName;
-    progress: number;
-    remainingCredits: number;
-    status: 'PASS' | 'FAIL';
-  }[] = [
-    { courseName: 'COMMON_GENERAL', progress: 100, remainingCredits: 0, status: 'PASS' },
-    { courseName: 'LIBERAL_ARTS', progress: 67, remainingCredits: 3, status: 'FAIL' },
-    { courseName: 'ACADEMIC_FOUNDATION', progress: 100, remainingCredits: 0, status: 'PASS' },
-    { courseName: 'FIRST_MAJOR', progress: 95, remainingCredits: 3, status: 'FAIL' },
-    { courseName: 'SECOND_MAJOR', progress: 92, remainingCredits: 3, status: 'FAIL' },
-  ];
-
-  const courseTabData = {
-    COMMON_GENERAL: {
-      areaDetails: [
-        {
-          areaName: '사고와표현',
-          chipVariant: 'satisfied' as const,
-          requiredCredits: 6,
-          completedCredits: 6,
-          subjects: [
-            { name: '글쓰기', credits: 3, chipVariant: 'satisfied' as const },
-            { name: '발표와토론', credits: 3, chipVariant: 'satisfied' as const },
-          ],
-        },
-        {
-          areaName: 'AI리터러시',
-          chipVariant: 'satisfied' as const,
-          requiredCredits: 3,
-          completedCredits: 3,
-          subjects: [{ name: 'AI활용기초', credits: 3, chipVariant: 'satisfied' as const }],
-        },
-        {
-          areaName: '채플',
-          chipVariant: 'satisfied' as const,
-          requiredCredits: 4,
-          completedCredits: 4,
-          subjects: [
-            { name: '채플', credits: 2, chipVariant: 'satisfied' as const },
-            { name: '채플', credits: 2, chipVariant: 'satisfied' as const },
-          ],
-        },
-      ],
-      unsatisfiedReasons: [],
-      completedCredits: 13,
-      targetCredits: 13,
-      remainingCredits: 0,
-    },
-    LIBERAL_ARTS: {
-      areaDetails: [
-        {
-          areaName: '인문',
-          chipVariant: 'satisfied' as const,
-          requiredCredits: 3,
-          completedCredits: 3,
-          subjects: [{ name: '철학입문', credits: 3, chipVariant: 'selected' as const }],
-        },
-        {
-          areaName: '사회',
-          chipVariant: 'satisfied' as const,
-          requiredCredits: 3,
-          completedCredits: 3,
-          subjects: [{ name: '경제학원론', credits: 3, chipVariant: 'selected' as const }],
-        },
-        {
-          areaName: '자연',
-          chipVariant: 'unsatisfied' as const,
-          requiredCredits: 3,
-          completedCredits: 0,
-          subjects: [{ name: '자연과학개론', credits: 3, chipVariant: 'unsatisfied' as const }],
-        },
-      ],
-      unsatisfiedReasons: ['자연 영역 미이수'],
-      completedCredits: 6,
-      targetCredits: 9,
-      remainingCredits: 3,
-    },
-    ACADEMIC_FOUNDATION: {
-      areaDetails: [
-        {
-          areaName: '수학',
-          chipVariant: 'satisfied' as const,
-          requiredCredits: 6,
-          completedCredits: 6,
-          subjects: [
-            { name: '미적분학', credits: 3, chipVariant: 'satisfied' as const },
-            { name: '선형대수', credits: 3, chipVariant: 'satisfied' as const },
-          ],
-        },
-        {
-          areaName: '과학',
-          chipVariant: 'satisfied' as const,
-          requiredCredits: 3,
-          completedCredits: 3,
-          subjects: [{ name: '물리학개론', credits: 3, chipVariant: 'satisfied' as const }],
-        },
-      ],
-      unsatisfiedReasons: [],
-      completedCredits: 9,
-      targetCredits: 9,
-      remainingCredits: 0,
-    },
-    FIRST_MAJOR: {
-      areaDetails: [
-        {
-          areaName: '전공필수',
-          chipVariant: 'unsatisfied' as const,
-          requiredCredits: 18,
-          completedCredits: 12,
-          subjects: [
-            { name: '자료구조', credits: 3, chipVariant: 'satisfied' as const },
-            { name: '운영체제', credits: 3, chipVariant: 'satisfied' as const },
-            { name: '알고리즘', credits: 3, chipVariant: 'satisfied' as const },
-            { name: '컴퓨터네트워크', credits: 3, chipVariant: 'satisfied' as const },
-            { name: '캡스톤디자인', credits: 3, chipVariant: 'unsatisfied' as const },
-            { name: '졸업프로젝트', credits: 3, chipVariant: 'unsatisfied' as const },
-          ],
-        },
-        {
-          areaName: '전공선택',
-          chipVariant: 'satisfied' as const,
-          requiredCredits: 42,
-          completedCredits: 42,
-          subjects: [
-            { name: '데이터베이스', credits: 3, chipVariant: 'selected' as const },
-            { name: '인공지능', credits: 3, chipVariant: 'selected' as const },
-            { name: '웹프로그래밍', credits: 3, chipVariant: 'selected' as const },
-          ],
-        },
-      ],
-      unsatisfiedReasons: ['캡스톤디자인 미이수', '졸업프로젝트 미이수'],
-      completedCredits: 57,
-      targetCredits: 60,
-      remainingCredits: 3,
-    },
-    SECOND_MAJOR: {
-      areaDetails: [
-        {
-          areaName: '경영필수',
-          chipVariant: 'unsatisfied' as const,
-          requiredCredits: 12,
-          completedCredits: 9,
-          subjects: [
-            { name: '경영학원론', credits: 3, chipVariant: 'satisfied' as const },
-            { name: '마케팅원론', credits: 3, chipVariant: 'satisfied' as const },
-            { name: '재무관리', credits: 3, chipVariant: 'satisfied' as const },
-            { name: '회계원리', credits: 3, chipVariant: 'unsatisfied' as const },
-          ],
-        },
-        {
-          areaName: '경영선택',
-          chipVariant: 'satisfied' as const,
-          requiredCredits: 24,
-          completedCredits: 24,
-          subjects: [
-            { name: '조직행동론', credits: 3, chipVariant: 'selected' as const },
-            { name: '인사관리', credits: 3, chipVariant: 'selected' as const },
-            { name: '경영정보시스템', credits: 3, chipVariant: 'selected' as const, details: ['ERP', '빅데이터분석'] },
-          ],
-        },
-      ],
-      unsatisfiedReasons: ['회계원리 미이수'],
-      completedCredits: 33,
-      targetCredits: 36,
-      remainingCredits: 3,
-    },
-  };
-
   const navigate = useNavigate();
+  const openAlert = useModalStore((state) => state.openAlert);
+  const { data, isPending, isError, error } = useReportSummary();
 
   const [headerRef, headerInView] = useInView();
   const [summaryRef, summaryInView] = useInView();
   const [areaRef, areaInView] = useInView();
   const [tabRef, tabInView] = useInView(0.1);
   const [buttonRef, buttonInView] = useInView();
+
+  const errorCode = isError ? error?.response?.data?.code : undefined;
+  // 적용 가능한 졸업 요건이 없는 학과(404 GRADUATION404_2)는 업로드의 미지원 학과 모달 문구를 재사용해 안내하고,
+  // 확인 시 홈으로 보낸다.
+  const isUnsupportedDept = errorCode === 'GRADUATION404_2';
+  useEffect(() => {
+    if (!isUnsupportedDept) return;
+    const modal = TRANSCRIPT_ERROR_MODAL.TRANSCRIPT400_3;
+    if (!modal) return;
+    openAlert({
+      icon: Warning,
+      title: modal.title,
+      subtitle: modal.subtitle,
+      description: modal.description,
+      buttonText: '닫기',
+      buttonVariant: 'primary',
+      onConfirm: () => navigate('/'),
+    });
+  }, [isUnsupportedDept, openAlert, navigate]);
+
+  if (isPending) {
+    return <Loading />;
+  }
+
+  if (isError) {
+    // 리포트 없음(404_1)은 업로드로 유도(게이트 우회 등 방어).
+    if (errorCode === 'GRADUATION404_1') {
+      return <Navigate to="/upload" replace />;
+    }
+    // 미지원 학과(404_2)는 위 모달을 띄우는 동안 로딩을 보여준다.
+    if (isUnsupportedDept) {
+      return <Loading />;
+    }
+    // 그 외 예기치 못한 오류는 NotFound.
+    return <NotFound />;
+  }
+
+  const { summary, areaOverviews } = data;
+  const graduationStatus: 'PASS' | 'FAIL' = summary.graduated ? 'PASS' : 'FAIL';
+  // 이 회원에게 적용되는 영역 탭 목록 (탭뷰가 활성 탭만 조회)
+  const courseTypes = areaOverviews.map((area) => area.courseType);
 
   return (
     <div className="flex flex-col p-20 gap-15">
@@ -212,27 +84,27 @@ export default function Graduation() {
       >
         <h3 className="text-heading-3 text-coolgray-90">요약</h3>
         <div className="flex flex-col gap-6 items-center">
-          <ProgressBar progress={progress} animate={summaryInView} />
-          <span className="text-heading-5 text-shimmer">졸업까지 {progress}% 달성했어요!</span>
+          <ProgressBar progress={summary.achievementRate} animate={summaryInView} />
+          <span className="text-heading-5 text-shimmer">졸업까지 {summary.achievementRate}% 달성했어요!</span>
         </div>
         <div className="w-full flex flex-col gap-3 px-115">
           <div className="flex justify-between">
             <span className="text-heading-5 text-coolgray-90">이수 학점</span>
-            <span className="text-heading-5 text-coolgray-90">{completedCredits}학점</span>
+            <span className="text-heading-5 text-coolgray-90">{summary.earnedCredits}학점</span>
           </div>
           <div className="flex justify-between">
             <span className="text-heading-5 text-coolgray-90">목표 이수 학점</span>
-            <span className="text-heading-5 text-coolgray-90">{targetCredits}학점</span>
+            <span className="text-heading-5 text-coolgray-90">{summary.targetCredits}학점</span>
           </div>
           <div className="flex justify-between">
             <span className="text-heading-5 text-coolgray-90">잔여 학점</span>
-            <span className="text-heading-5 text-primary-60">{remainingCredits}학점</span>
+            <span className="text-heading-5 text-primary-60">{summary.remainingCredits}학점</span>
           </div>
         </div>
         <div className="w-full flex flex-col gap-3 px-100">
           <div className="w-full flex justify-between">
             <span className="text-heading-4 text-coolgray-90">총 평점 평균</span>
-            <span className="text-heading-4 text-coolgray-90">{gpa}</span>
+            <span className="text-heading-4 text-coolgray-90">{summary.gpa}</span>
           </div>
           <div className="w-full flex justify-between">
             <span className="text-heading-3 text-primary-60">졸업 판정</span>
@@ -243,6 +115,17 @@ export default function Graduation() {
             </span>
           </div>
         </div>
+
+        {/* 전체 졸업요건 미충족 사유 (없으면 숨김). 졸업 판정 아래 중앙 정렬, 영역별 사유와 동일한 글씨 */}
+        {summary.unsatisfiedReasons.length > 0 && (
+          <div className="flex flex-col items-center gap-1 mt-4">
+            {summary.unsatisfiedReasons.map((reason) => (
+              <span key={reason} className="text-button-m text-alert">
+                {reason}
+              </span>
+            ))}
+          </div>
+        )}
       </div>
 
       {/* 영역별 이수 현황 */}
@@ -255,13 +138,13 @@ export default function Graduation() {
           <p className="text-body-m text-coolgray-60">아래에서 원하는 영역 탭을 클릭해 자세한 정보를 확인하세요.</p>
         </div>
         <div className="flex gap-3 overflow-x-auto">
-          {courseSummary.map((course) => (
+          {areaOverviews.map((area) => (
             <CourseSummaryCard
-              key={course.courseName}
-              courseName={course.courseName}
-              progress={course.progress}
-              remainingCredits={course.remainingCredits}
-              status={course.status}
+              key={area.courseType}
+              courseName={area.courseType}
+              progress={area.achievementRate}
+              remainingCredits={area.remainingCredits}
+              status={area.satisfied ? 'PASS' : 'FAIL'}
               isVisible={areaInView}
             />
           ))}
@@ -273,7 +156,7 @@ export default function Graduation() {
         ref={tabRef}
         className={`w-full py-4 px-10 border-b border-coolgray-20 ${tabInView ? 'animate-fade-in-up' : 'opacity-0'}`}
       >
-        <CourseTabView data={courseTabData} />
+        <CourseTabView courseTypes={courseTypes} />
       </div>
 
       {/* 버튼 */}

--- a/src/types/report/TGetReportDetail.ts
+++ b/src/types/report/TGetReportDetail.ts
@@ -1,0 +1,38 @@
+import type { TCommonResponse } from '@/types/common';
+
+// GET /api/reports?courseType={courseType} 응답 — courseType 내 영역(areaType)별 상세 이수 현황
+
+// 과목 이수 상태
+export type TReportItemStatus = 'SATISFIED' | 'UNSATISFIED' | 'OPTIONAL'; // 필수 이수 / 필수 미이수 / 선택 이수
+
+// 영역 내 개별 과목
+export type TReportAreaItem = {
+  title: string; // 과목명
+  credit: number; // 이수 학점 (미이수 필수과목은 0)
+  status: TReportItemStatus;
+  detail: string[] | null; // 부가 설명 (없으면 null)
+};
+
+// 영역(areaType)별 상세
+export type TReportAreaDetail = {
+  areaName: string; // 영역 이름
+  earnedCredits: number; // 해당 영역 이수 학점
+  targetCredits: number; // 해당 영역 목표 학점
+  satisfied: boolean; // 해당 영역 필수 요건 충족 여부
+  items: TReportAreaItem[];
+};
+
+// 해당 courseType 전체 학점 현황
+export type TReportCreditStatus = {
+  earnedCredits: number;
+  targetCredits: number;
+  remainingCredits: number;
+};
+
+export type TGetReportDetailResult = {
+  areaDetails: TReportAreaDetail[];
+  unsatisfiedReasons: string[]; // 해당 courseType 미충족 졸업 규칙 사유
+  creditStatus: TReportCreditStatus;
+};
+
+export type TGetReportDetailResponse = TCommonResponse<TGetReportDetailResult>;

--- a/src/types/report/TGetReportSummary.ts
+++ b/src/types/report/TGetReportSummary.ts
@@ -1,0 +1,31 @@
+import type { TCommonResponse } from '@/types/common';
+import type { TCourseName } from '@/types/course';
+
+// GET /api/reports/summary 응답 — 전체 졸업 달성률 요약 + courseType별 이수 현황
+
+// 상단 요약
+export type TReportSummary = {
+  achievementRate: number; // 전체 졸업 달성률 (0~100)
+  earnedCredits: number; // 현재 이수 학점
+  targetCredits: number; // 목표 이수 학점
+  remainingCredits: number; // 잔여 학점
+  gpa: number; // 총 평점 평균
+  graduated: boolean; // 졸업 판정 여부
+  unsatisfiedReasons: string[]; // 졸업요건 부문 미충족 사유 목록
+};
+
+// 영역(courseType)별 개요 카드
+export type TAreaOverview = {
+  courseType: TCourseName; // COMMON_GENERAL, LIBERAL_ARTS, ...
+  courseTypeName: string; // 공통교양, 일반교양, ...
+  achievementRate: number; // 해당 영역 달성률 (0~100)
+  remainingCredits: number; // 해당 영역 잔여 학점
+  satisfied: boolean; // 해당 영역 요건 충족 여부
+};
+
+export type TGetReportSummaryResult = {
+  summary: TReportSummary;
+  areaOverviews: TAreaOverview[];
+};
+
+export type TGetReportSummaryResponse = TCommonResponse<TGetReportSummaryResult>;


### PR DESCRIPTION
## 📋 작업 내용
- 졸업 판정 화면(요약·영역 카드·영역 상세 탭)을 리포트 API로 연동

## 🎯 관련 이슈
- closes #45

## 📝 변경 사항
- getReportSummary·getReportDetail API와 useReportSummary·useReportDetail 훅·응답 타입 추가
- graduation 요약/영역 카드 summary 연동, 졸업 판정(PASS/FAIL) 표시
- CourseTabView를 활성 탭만 조회하는 지연 로딩 방식으로 전환 (탭별 캐시)
- 미지원 학과(GRADUATION404_2) 안내 모달(업로드 미지원 학과 문구 재사용), 리포트 없음(404_1) 업로드 유도

## 📸 스크린샷 (선택사항)
<!--
필요한 경우 스크린샷 첨부
-->
