### PR TITLE
[Feat] 회원 프로필 수정 및 탈퇴 API 연동 구현

### DIFF
--- a/src/apis/user/user.ts
+++ b/src/apis/user/user.ts
@@ -1,8 +1,22 @@
 import axiosInstance from '@/apis/axiosInstance';
+import type { TCommonResponse } from '@/types/common';
 import type { TGetUserInfoResponse } from '@/types/user/TGetUserInfo';
+import type { TPatchProfileRequest, TPatchProfileResponse } from '@/types/user/TPatchProfile';
 
 // 로그인한 사용자 정보 조회
 export const getUserInfo = async () => {
   const { data } = await axiosInstance.get<TGetUserInfoResponse>('/api/users/me');
   return data.result;
+};
+
+// 프로필 수정 (학번·이름·닉네임). 본인 인증 후 학번/이름 변경 시 409(USER409_3), 학번 중복 시 409(USER409_2).
+export const patchProfile = async (body: TPatchProfileRequest) => {
+  const { data } = await axiosInstance.patch<TPatchProfileResponse>('/api/users/me', body);
+  return data.result;
+};
+
+// 회원 탈퇴 (soft-delete).
+export const deleteAccount = async () => {
+  const { data } = await axiosInstance.delete<TCommonResponse<null>>('/api/users/me');
+  return data;
 };

--- a/src/components/chip.tsx
+++ b/src/components/chip.tsx
@@ -2,6 +2,8 @@ export type TChipVariant = 'satisfied' | 'unsatisfied' | 'selected';
 
 interface IChipProps {
   variant: TChipVariant;
+  // 기본 라벨(충족/불충족/선택) 대신 커스텀 텍스트를 쓰고 싶을 때 사용한다.
+  label?: string;
 }
 
 const CHIP_LABEL: Record<TChipVariant, string> = {
@@ -16,6 +18,10 @@ const CHIP_STYLE: Record<TChipVariant, string> = {
   selected: 'bg-coolgray-10 text-coolgray-60',
 };
 
-export default function Chip({ variant }: IChipProps) {
-  return <span className={`text-body-s rounded-[12px] px-3 py-0.5 ${CHIP_STYLE[variant]}`}>{CHIP_LABEL[variant]}</span>;
+export default function Chip({ variant, label }: IChipProps) {
+  return (
+    <span className={`text-body-s rounded-[12px] px-3 py-0.5 ${CHIP_STYLE[variant]}`}>
+      {label ?? CHIP_LABEL[variant]}
+    </span>
+  );
 }

--- a/src/components/common/textField.tsx
+++ b/src/components/common/textField.tsx
@@ -7,7 +7,7 @@ export default function TextField({ className = '', error, ...props }: ITextFiel
     <div className={`w-80 ${className}`}>
       <input
         {...props}
-        className={`w-full px-4 py-3 rounded-lg bg-white border text-body-m placeholder:text-coolgray-60 outline-none ${
+        className={`w-full px-4 py-3 rounded-lg bg-white border text-body-m placeholder:text-coolgray-60 outline-none disabled:bg-coolgray-10 disabled:text-coolgray-60 disabled:cursor-not-allowed ${
           error ? 'border-alert' : 'border-coolgray-30'
         }`}
       />

--- a/src/components/onBoardingModal.tsx
+++ b/src/components/onBoardingModal.tsx
@@ -7,15 +7,18 @@ import { useModalStore } from '@/stores/modalStore';
 
 // 클라이언트 입력 검증 (서버 규칙과 동일하게 맞춘다)
 // 이름: 필수, 5자 이하 / 학번: 필수, 숫자 10자리
+// blur/입력 중과 제출 시 결과가 일치하도록 검증 함수 내부에서 먼저 trim한 뒤 검사한다.
 const validateName = (value: string): string => {
-  if (!value.trim()) return '*이름을 입력해주세요.';
-  if (value.length > 5) return '*이름은 5자 이하로 입력해주세요.';
+  const trimmed = value.trim();
+  if (!trimmed) return '*이름을 입력해주세요.';
+  if (trimmed.length > 5) return '*이름은 5자 이하로 입력해주세요.';
   return '';
 };
 
 const validateStudentId = (value: string): string => {
-  if (!value) return '*학번을 입력해주세요.';
-  if (!/^\d{10}$/.test(value)) return '*학번은 숫자 10자리로 입력해주세요.';
+  const trimmed = value.trim();
+  if (!trimmed) return '*학번을 입력해주세요.';
+  if (!/^\d{10}$/.test(trimmed)) return '*학번은 숫자 10자리로 입력해주세요.';
   return '';
 };
 

--- a/src/hooks/user/useDeleteAccount.ts
+++ b/src/hooks/user/useDeleteAccount.ts
@@ -1,0 +1,24 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+
+import { deleteAccount } from '@/apis/user/user';
+import { useCoreMutation } from '@/hooks/customQuery';
+import { useAuthStore } from '@/stores/authStore';
+import type { TCommonResponse } from '@/types/common';
+
+// 회원 탈퇴 훅.
+// 성공 시 로그아웃과 동일하게 인증을 비우고 캐시를 정리한 뒤 홈으로 이동한다.
+// (탈퇴 변수가 없으므로 mutation 변수 타입을 void로 지정)
+export default function useDeleteAccount() {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const clearAuth = useAuthStore((state) => state.clearAuth);
+
+  return useCoreMutation<TCommonResponse<null>, void>(() => deleteAccount(), {
+    onSuccess: () => {
+      clearAuth();
+      queryClient.clear();
+      navigate('/');
+    },
+  });
+}

--- a/src/hooks/user/useUpdateProfile.ts
+++ b/src/hooks/user/useUpdateProfile.ts
@@ -1,0 +1,38 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+import { patchProfile } from '@/apis/user/user';
+import { QUERY_KEYS } from '@/constants/querykeys/queryKeys';
+import { useCoreMutation } from '@/hooks/customQuery';
+import type { TResponseError } from '@/types/common';
+import type { TPatchProfileRequest } from '@/types/user/TPatchProfile';
+
+// 프로필 수정 훅.
+// 성공 시 사용자 정보 캐시를 무효화하고 안내 토스트를 띄운다(페이지에 머문다).
+// onError를 직접 제공하므로(either/or) 코드별로 분기한다.
+export default function useUpdateProfile() {
+  const queryClient = useQueryClient();
+
+  return useCoreMutation((body: TPatchProfileRequest) => patchProfile(body), {
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.GET_USER_INFO });
+      toast.success('프로필이 수정되었어요.');
+    },
+    onError: (error: TResponseError) => {
+      const code = error.response?.data?.code;
+
+      // 학번 중복은 제출 시점에만 알 수 있어 토스트로 안내.
+      if (code === 'USER409_2') {
+        toast.error('이미 가입한 학번입니다.');
+        return;
+      }
+      // 본인 인증 후 학번/이름 변경 시도 (UI에서 잠그지만 방어적 안내).
+      if (code === 'USER409_3') {
+        toast.error('본인 인증 후에는 학번과 이름을 변경할 수 없어요.');
+        return;
+      }
+      // 그 외(온보딩 미완료·회원 없음 등)는 서버 메시지를 토스트로 안내.
+      toast.error(error.response?.data?.message ?? '프로필 수정 중 오류가 발생했어요.');
+    },
+  });
+}

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -1,26 +1,124 @@
 import { useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 import User from '@/assets/icons/user.svg?react';
 import Warning from '@/assets/icons/warning.svg?react';
 import ProfileImage from '@/assets/profileImage.svg?react';
+import Chip from '@/components/chip';
 import Button from '@/components/common/button';
+import Loading from '@/components/common/loading';
 import TextField from '@/components/common/textField';
 import useInView from '@/hooks/useInView';
+import useDeleteAccount from '@/hooks/user/useDeleteAccount';
+import useUpdateProfile from '@/hooks/user/useUpdateProfile';
+import useUserInfo from '@/hooks/user/useUserInfo';
+import NotFound from '@/pages/notFound';
 import { useModalStore } from '@/stores/modalStore';
 
-const PROFILE_FIELDS = [
-  { label: '이름', placeholder: '이름을 입력해주세요' },
-  { label: '닉네임', placeholder: '닉네임을 입력해주세요' },
-  { label: '학번', placeholder: '학번을 입력해주세요' },
-] as const;
+// 클라이언트 입력 검증 (서버 규칙과 동일). 이름 ≤5, 학번 숫자 10자리, 닉네임 ≤8
+const validateName = (value: string): string => {
+  if (!value.trim()) return '*이름을 입력해주세요.';
+  if (value.length > 5) return '*이름은 5자 이하로 입력해주세요.';
+  return '';
+};
+
+const validateStudentId = (value: string): string => {
+  if (!value) return '*학번을 입력해주세요.';
+  if (!/^\d{10}$/.test(value)) return '*학번은 숫자 10자리로 입력해주세요.';
+  return '';
+};
+
+const validateNickname = (value: string): string => {
+  if (!value.trim()) return '*닉네임을 입력해주세요.';
+  if (value.length > 8) return '*닉네임은 8자 이하로 입력해주세요.';
+  return '';
+};
 
 export default function Profile() {
-  const navigate = useNavigate();
   const [ref, isInView] = useInView();
+  const { openAlert } = useModalStore();
+  const { data, isPending, isError } = useUserInfo();
+  const { mutate: updateProfile, isPending: isUpdating } = useUpdateProfile();
+  const { mutate: deleteAccount } = useDeleteAccount();
+
+  // 본인 인증 완료 시 이름·학번은 잠금(수정 불가).
+  const identityVerified = data?.identityVerified ?? false;
+
+  // 폼 입력값 (조회 데이터로 초기화). 캐시가 비어 늦게 도착하는 경우를 대비해 seededRef로 한 번 더 채운다.
+  const [name, setName] = useState(data?.name ?? '');
+  const [nickname, setNickname] = useState(data?.nickname ?? '');
+  const [studentId, setStudentId] = useState(data?.studentId ?? '');
+  const seededRef = useRef(false);
+
+  const [nameError, setNameError] = useState('');
+  const [nicknameError, setNicknameError] = useState('');
+  const [studentIdError, setStudentIdError] = useState('');
+  const [touched, setTouched] = useState({ name: false, nickname: false, studentId: false });
+
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const { openAlert } = useModalStore();
+
+  // 사용자 정보가 처음 도착하면 폼을 채운다. (이미 채웠으면 사용자의 편집을 덮어쓰지 않음)
+  useEffect(() => {
+    if (!data || seededRef.current) return;
+    seededRef.current = true;
+    setName(data.name ?? '');
+    setNickname(data.nickname ?? '');
+    setStudentId(data.studentId ?? '');
+  }, [data]);
+
+  // 프로필 이미지 미리보기 URL 정리 (메모리 누수 방지). 이미지 업로드는 별도 API가 없어 로컬 미리보기만 지원한다.
+  useEffect(() => {
+    return () => {
+      if (previewUrl) URL.revokeObjectURL(previewUrl);
+    };
+  }, [previewUrl]);
+
+  // 입력 변경: 이미 검증이 시작된 필드는 실시간으로 에러를 갱신한다.
+  const handleNameChange = (value: string) => {
+    setName(value);
+    if (touched.name) setNameError(validateName(value));
+  };
+  const handleNicknameChange = (value: string) => {
+    setNickname(value);
+    if (touched.nickname) setNicknameError(validateNickname(value));
+  };
+  const handleStudentIdChange = (value: string) => {
+    setStudentId(value);
+    if (touched.studentId) setStudentIdError(validateStudentId(value));
+  };
+
+  // 포커스가 빠지면 검증을 시작하고 에러를 표시한다. (stale 값 방지 위해 이벤트 값 직접 사용)
+  const handleNameBlur = (value: string) => {
+    setTouched((prev) => ({ ...prev, name: true }));
+    setNameError(validateName(value));
+  };
+  const handleNicknameBlur = (value: string) => {
+    setTouched((prev) => ({ ...prev, nickname: true }));
+    setNicknameError(validateNickname(value));
+  };
+  const handleStudentIdBlur = (value: string) => {
+    setTouched((prev) => ({ ...prev, studentId: true }));
+    setStudentIdError(validateStudentId(value));
+  };
+
+  const handleSubmit = () => {
+    const trimmedName = name.trim();
+    const trimmedNickname = nickname.trim();
+    const trimmedStudentId = studentId.trim();
+
+    // 본인 인증 시 이름·학번은 잠겨 서버 값 그대로 전송되므로 닉네임만 검증한다.
+    const nextNameError = identityVerified ? '' : validateName(trimmedName);
+    const nextStudentIdError = identityVerified ? '' : validateStudentId(trimmedStudentId);
+    const nextNicknameError = validateNickname(trimmedNickname);
+    setNameError(nextNameError);
+    setStudentIdError(nextStudentIdError);
+    setNicknameError(nextNicknameError);
+    setTouched({ name: true, nickname: true, studentId: true });
+    if (nextNameError || nextStudentIdError || nextNicknameError) return;
+
+    updateProfile({ studentId: trimmedStudentId, name: trimmedName, nickname: trimmedNickname });
+  };
+
   const handleOpenModal = () => {
     openAlert({
       icon: Warning,
@@ -29,15 +127,9 @@ export default function Profile() {
       description: '회원 탈퇴는 신중하게 해주세요.\n다른 문제가 있다면 고객지원에 문의해주세요.',
       buttonText: '탈퇴하기',
       buttonVariant: 'alert',
-      onConfirm: () => {},
+      onConfirm: () => deleteAccount(),
     });
   };
-
-  useEffect(() => {
-    return () => {
-      if (previewUrl) URL.revokeObjectURL(previewUrl);
-    };
-  }, [previewUrl]);
 
   const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const selected = e.target.files?.[0];
@@ -50,6 +142,14 @@ export default function Profile() {
   const handleImageDelete = () => {
     setPreviewUrl(null);
   };
+
+  // 사용자 정보 조회 상태 처리
+  if (isPending) {
+    return <Loading />;
+  }
+  if (isError || !data) {
+    return <NotFound />;
+  }
 
   return (
     <div
@@ -87,17 +187,52 @@ export default function Profile() {
           </div>
         </div>
         <div className="flex flex-1 flex-col items-start gap-6 p-4">
-          {PROFILE_FIELDS.map(({ label, placeholder }) => (
-            <div key={label} className="flex flex-col items-start gap-1">
-              <p className="text-body-m text-coolgray-90">{label}</p>
-              <TextField placeholder={placeholder} />
-            </div>
-          ))}
+          {/* 본인 인증 상태 칩 (맨 위, 왼쪽 정렬) */}
+          <Chip
+            variant={identityVerified ? 'satisfied' : 'unsatisfied'}
+            label={identityVerified ? '본인 인증 완료' : '본인 인증 미완료'}
+          />
+
+          <div className="flex flex-col items-start gap-1">
+            <p className="text-body-m text-coolgray-90">학번</p>
+            <TextField
+              placeholder="학번을 입력해주세요"
+              value={studentId}
+              inputMode="numeric"
+              disabled={identityVerified}
+              onChange={(e) => handleStudentIdChange(e.target.value)}
+              onBlur={(e) => handleStudentIdBlur(e.target.value)}
+              error={studentIdError}
+            />
+          </div>
+
+          <div className="flex flex-col items-start gap-1">
+            <p className="text-body-m text-coolgray-90">이름</p>
+            <TextField
+              placeholder="이름을 입력해주세요"
+              value={name}
+              disabled={identityVerified}
+              onChange={(e) => handleNameChange(e.target.value)}
+              onBlur={(e) => handleNameBlur(e.target.value)}
+              error={nameError}
+            />
+          </div>
+
+          <div className="flex flex-col items-start gap-1">
+            <p className="text-body-m text-coolgray-90">닉네임</p>
+            <TextField
+              placeholder="닉네임을 입력해주세요"
+              value={nickname}
+              onChange={(e) => handleNicknameChange(e.target.value)}
+              onBlur={(e) => handleNicknameBlur(e.target.value)}
+              error={nicknameError}
+            />
+          </div>
         </div>
       </div>
 
       <div className="flex items-center gap-4">
-        <Button className="w-40" onClick={() => navigate('/')}>
+        <Button className="w-40" onClick={handleSubmit} disabled={isUpdating}>
           수정하기
         </Button>
         <Button variant="alert" className="w-40" onClick={handleOpenModal}>

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -15,21 +15,25 @@ import NotFound from '@/pages/notFound';
 import { useModalStore } from '@/stores/modalStore';
 
 // 클라이언트 입력 검증 (서버 규칙과 동일). 이름 ≤5, 학번 숫자 10자리, 닉네임 ≤8
+// blur/입력 중과 제출 시 결과가 일치하도록 검증 함수 내부에서 먼저 trim한 뒤 검사한다.
 const validateName = (value: string): string => {
-  if (!value.trim()) return '*이름을 입력해주세요.';
-  if (value.length > 5) return '*이름은 5자 이하로 입력해주세요.';
+  const trimmed = value.trim();
+  if (!trimmed) return '*이름을 입력해주세요.';
+  if (trimmed.length > 5) return '*이름은 5자 이하로 입력해주세요.';
   return '';
 };
 
 const validateStudentId = (value: string): string => {
-  if (!value) return '*학번을 입력해주세요.';
-  if (!/^\d{10}$/.test(value)) return '*학번은 숫자 10자리로 입력해주세요.';
+  const trimmed = value.trim();
+  if (!trimmed) return '*학번을 입력해주세요.';
+  if (!/^\d{10}$/.test(trimmed)) return '*학번은 숫자 10자리로 입력해주세요.';
   return '';
 };
 
 const validateNickname = (value: string): string => {
-  if (!value.trim()) return '*닉네임을 입력해주세요.';
-  if (value.length > 8) return '*닉네임은 8자 이하로 입력해주세요.';
+  const trimmed = value.trim();
+  if (!trimmed) return '*닉네임을 입력해주세요.';
+  if (trimmed.length > 8) return '*닉네임은 8자 이하로 입력해주세요.';
   return '';
 };
 
@@ -116,7 +120,16 @@ export default function Profile() {
     setTouched({ name: true, nickname: true, studentId: true });
     if (nextNameError || nextStudentIdError || nextNicknameError) return;
 
-    updateProfile({ studentId: trimmedStudentId, name: trimmedName, nickname: trimmedNickname });
+    updateProfile(
+      { studentId: trimmedStudentId, name: trimmedName, nickname: trimmedNickname },
+      {
+        // 수정 성공 후 무효화로 다시 받아온 서버 데이터가 폼에 반영되도록 시드 플래그를 초기화한다.
+        // (서버 정규화·다중 기기 등으로 값이 달라진 경우 폼을 최신 상태로 동기화)
+        onSuccess: () => {
+          seededRef.current = false;
+        },
+      },
+    );
   };
 
   const handleOpenModal = () => {

--- a/src/types/user/TPatchProfile.ts
+++ b/src/types/user/TPatchProfile.ts
@@ -1,0 +1,11 @@
+import type { TGetUserInfoResponse } from '@/types/user/TGetUserInfo';
+
+// PATCH /api/users/me 요청 바디 (모두 필수). 본인 인증 후에는 학번/이름 변경 불가(서버 409 USER409_3).
+export type TPatchProfileRequest = {
+  studentId: string;
+  name: string;
+  nickname: string;
+};
+
+// 응답 result는 GET /api/users/me와 동형(studentId/name/nickname/identityVerified)이라 재사용한다.
+export type TPatchProfileResponse = TGetUserInfoResponse;


### PR DESCRIPTION
## 📋 작업 내용
- 프로필 관리 화면에 사용자 정보 조회/수정(PATCH)과 회원 탈퇴(DELETE)를 연동

## 🎯 관련 이슈
- closes #47

## 📝 변경 사항
- patchProfile·deleteAccount API와 useUpdateProfile·useDeleteAccount 훅 추가
- 진입 시 사용자 정보로 폼 초기화, 본인 인증 완료 시 이름·학번 잠금(음영) 및 인증 상태 칩 표시
- 이름·학번·닉네임 클라이언트 검증 추가(온보딩과 동일 방식), 제출 시 trim
- 수정 성공 시 사용자 정보 캐시 무효화·토스트(페이지 유지), 학번 중복/인증 후 변경 시도 분기
- 탈퇴 모달 확인 시 회원 탈퇴 후 로그아웃 처리
- 공용 TextField disabled 음영 스타일, Chip 커스텀 label 옵션 추가(하위호환)

## 📸 스크린샷 (선택사항)
<!--
필요한 경우 스크린샷 첨부
-->
