### PR TITLE
[Feat] 수강 이력 추가 API 연동 구현

### DIFF
--- a/src/apis/report/report.ts
+++ b/src/apis/report/report.ts
@@ -3,6 +3,7 @@ import type { TCourseName } from '@/types/course';
 import type { TGetReportDetailResponse } from '@/types/report/TGetReportDetail';
 import type { TGetReportSummaryResponse } from '@/types/report/TGetReportSummary';
 import type { TGetUserReportsResponse } from '@/types/report/TGetUserReports';
+import type { TPatchReportRequest, TPatchReportResponse } from '@/types/report/TPatchReport';
 import type { TPutTranscriptResponse } from '@/types/report/TPutTranscript';
 
 // 성적표(학업 리포트) 조회. 성적표가 없으면 404(TRANSCRIPT404_1)를 반환한다.
@@ -20,6 +21,12 @@ export const getReportSummary = async () => {
 // courseType별 영역 상세 조회. 잘못된 courseType은 400(COMMON400_1).
 export const getReportDetail = async (courseType: TCourseName) => {
   const { data } = await axiosInstance.get<TGetReportDetailResponse>('/api/reports', { params: { courseType } });
+  return data.result;
+};
+
+// 수강 이력 수동 추가. 성적표 없으면 404(TRANSCRIPT404_1), 허용되지 않은 성적 값은 400(TRANSCRIPT400_4).
+export const patchReportCourses = async (body: TPatchReportRequest) => {
+  const { data } = await axiosInstance.patch<TPatchReportResponse>('/api/users/me/reports', body);
   return data.result;
 };
 

--- a/src/hooks/report/useAddCourses.ts
+++ b/src/hooks/report/useAddCourses.ts
@@ -1,0 +1,43 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+
+import { patchReportCourses } from '@/apis/report/report';
+import { QUERY_KEYS } from '@/constants/querykeys/queryKeys';
+import { useCoreMutation } from '@/hooks/customQuery';
+import type { TResponseError } from '@/types/common';
+import type { TPatchReportRequest } from '@/types/report/TPatchReport';
+
+// 수강 이력 수동 추가 훅.
+// 성공 시 학업 리포트와 졸업 판정 캐시를 무효화하고 안내 토스트를 띄운다.
+export default function useAddCourses() {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  return useCoreMutation((body: TPatchReportRequest) => patchReportCourses(body), {
+    onSuccess: () => {
+      // 수강 이력이 바뀌었으므로 성적표 조회와 졸업 판정(요약·영역상세) 캐시를 무효화한다.
+      // ['reports'] 접두사로 요약(['reports','summary'])·영역상세(['reports',{courseType}])를 한 번에 무효화한다.
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.GET_USER_REPORTS });
+      queryClient.invalidateQueries({ queryKey: ['reports'] });
+      toast.success('수강 이력이 추가되었어요.');
+    },
+    onError: (error: TResponseError) => {
+      const status = error.response?.status;
+      const code = error.response?.data?.code;
+
+      // 성적표가 없으면(404 TRANSCRIPT404_1) 업로드로 유도.
+      if (status === 404) {
+        navigate('/upload', { replace: true });
+        return;
+      }
+      // 허용되지 않은 성적 값.
+      if (code === 'TRANSCRIPT400_4') {
+        toast.error('성적 값이 올바르지 않아요. (예: A+, B0, P)');
+        return;
+      }
+      // 그 외(필수 누락 등)는 서버 메시지를 토스트로 안내.
+      toast.error(error.response?.data?.message ?? '수강 이력 추가 중 오류가 발생했어요.');
+    },
+  });
+}

--- a/src/pages/academicRecords.tsx
+++ b/src/pages/academicRecords.tsx
@@ -1,14 +1,19 @@
 import { useRef, useState } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
 
 import Edit from '@/assets/icons/edit.svg?react';
 import Button from '@/components/common/button';
 import Loading from '@/components/common/loading';
 import TextField from '@/components/common/textField';
+import useAddCourses from '@/hooks/report/useAddCourses';
 import useUserReports from '@/hooks/report/useUserReports';
 import useInView from '@/hooks/useInView';
 import NotFound from '@/pages/notFound';
 import type { TTranscriptRecord } from '@/types/report/TGetUserReports';
+
+// 추가 수강 이력의 성적 허용값 (서버 enum과 동일)
+const ALLOWED_GRADES = ['A+', 'A0', 'B+', 'B0', 'C+', 'C0', 'D+', 'D0', 'F', 'P', 'NP'];
 
 interface ICourse {
   category: string;
@@ -68,6 +73,7 @@ export default function AcademicRecords() {
   const [addedCourses, setAddedCourses] = useState<Record<string, IAddedCourse[]>>({});
   const nextId = useRef(0);
   const { data, isPending, isError, error } = useUserReports();
+  const { mutate: addCourses, isPending: isAdding } = useAddCourses();
 
   const hasNewCourses = Object.values(addedCourses).some((courses) => courses.length > 0);
 
@@ -91,6 +97,40 @@ export default function AcademicRecords() {
       ...prev,
       [semester]: (prev[semester] ?? []).map((course) => (course.id === id ? { ...course, [field]: parsed } : course)),
     }));
+  };
+
+  // "수정하기": 학기별로 추가한 행을 검증한 뒤 한 번에 PATCH로 반영한다.
+  const handleSubmitCourses = () => {
+    // 학기별 추가행을 학기 정보와 함께 평탄화한다.
+    const flattened = Object.entries(addedCourses).flatMap(([semester, list]) =>
+      list.map((course) => ({ semester, course })),
+    );
+    if (flattened.length === 0) return;
+
+    // 클라이언트 검증: 필수항목(이수구분·학수번호·교과목명·성적) 채움, 학점 0 이상, 성적 enum (이수영역은 선택)
+    const isValid = flattened.every(({ course }) => {
+      const grade = course.grade.trim().toUpperCase();
+      const filled = course.category.trim() && course.courseCode.trim() && course.courseName.trim() && grade;
+      return filled && course.credits >= 0 && ALLOWED_GRADES.includes(grade);
+    });
+    if (!isValid) {
+      toast.error('추가한 과목의 모든 항목을 올바르게 입력해주세요. (성적은 A+·B0·P 등)');
+      return;
+    }
+
+    const courses = flattened.map(({ semester, course }) => ({
+      semester,
+      courseType: course.category.trim(),
+      ...(course.area.trim() ? { areaName: course.area.trim() } : {}),
+      courseCode: course.courseCode.trim(),
+      courseName: course.courseName.trim(),
+      credits: course.credits,
+      grade: course.grade.trim().toUpperCase(),
+      retake: course.retake === 'O',
+    }));
+
+    // 성공 시 추가행을 비운다. (무효화로 다시 받아온 데이터에서 기존 수강으로 합류)
+    addCourses({ courses }, { onSuccess: () => setAddedCourses({}) });
   };
 
   // 성적표 조회 상태 처리: 로딩 → 공용 Loading, 미업로드(404) → 업로드 유도, 그 외 에러 → NotFound
@@ -237,7 +277,12 @@ export default function AcademicRecords() {
         <Button variant="outlined" className="w-40" onClick={() => navigate('/upload')}>
           PDF 새로 업로드하기
         </Button>
-        <Button variant={hasNewCourses ? 'primary' : 'disabled'} className="w-40">
+        <Button
+          variant={hasNewCourses && !isAdding ? 'primary' : 'disabled'}
+          className="w-40"
+          disabled={!hasNewCourses || isAdding}
+          onClick={handleSubmitCourses}
+        >
           수정하기
         </Button>
       </div>

--- a/src/pages/academicRecords.tsx
+++ b/src/pages/academicRecords.tsx
@@ -118,16 +118,20 @@ export default function AcademicRecords() {
       return;
     }
 
-    const courses = flattened.map(({ semester, course }) => ({
-      semester,
-      courseType: course.category.trim(),
-      ...(course.area.trim() ? { areaName: course.area.trim() } : {}),
-      courseCode: course.courseCode.trim(),
-      courseName: course.courseName.trim(),
-      credits: course.credits,
-      grade: course.grade.trim().toUpperCase(),
-      retake: course.retake === 'O',
-    }));
+    const courses = flattened.map(({ semester, course }) => {
+      // 기존 데이터의 빈 영역은 '-'로 표시되므로, 빈값과 '-' 모두 areaName에서 제외한다.
+      const trimmedArea = course.area.trim();
+      return {
+        semester,
+        courseType: course.category.trim(),
+        ...(trimmedArea && trimmedArea !== '-' ? { areaName: trimmedArea } : {}),
+        courseCode: course.courseCode.trim(),
+        courseName: course.courseName.trim(),
+        credits: course.credits,
+        grade: course.grade.trim().toUpperCase(),
+        retake: course.retake === 'O',
+      };
+    });
 
     // 성공 시 추가행을 비운다. (무효화로 다시 받아온 데이터에서 기존 수강으로 합류)
     addCourses({ courses }, { onSuccess: () => setAddedCourses({}) });
@@ -225,6 +229,7 @@ export default function AcademicRecords() {
                         <input
                           type="checkbox"
                           checked={newCourse.retake === 'O'}
+                          disabled={isAdding}
                           onChange={(e) =>
                             handleNewCourseChange(
                               semesterData.semester,
@@ -241,6 +246,7 @@ export default function AcademicRecords() {
                         className="!w-full"
                         placeholder={col.label}
                         value={newCourse[col.key]}
+                        disabled={isAdding}
                         onChange={(e) =>
                           handleNewCourseChange(semesterData.semester, newCourse.id, col.key, e.target.value)
                         }
@@ -252,7 +258,8 @@ export default function AcademicRecords() {
                 <div className="flex w-[4%] justify-center">
                   <button
                     type="button"
-                    className="cursor-pointer text-body-m text-coolgray-60 hover:text-primary-60"
+                    disabled={isAdding}
+                    className="cursor-pointer text-body-m text-coolgray-60 hover:text-primary-60 disabled:cursor-not-allowed disabled:opacity-50"
                     onClick={() => handleDeleteCourse(semesterData.semester, newCourse.id)}
                   >
                     ✕
@@ -263,7 +270,12 @@ export default function AcademicRecords() {
 
             {/* 추가 버튼 */}
             <div className="flex w-full justify-end py-3">
-              <Button variant="outlined" className="w-16 h-10" onClick={() => handleAddCourse(semesterData.semester)}>
+              <Button
+                variant={isAdding ? 'disabled' : 'outlined'}
+                className="w-16 h-10"
+                disabled={isAdding}
+                onClick={() => handleAddCourse(semesterData.semester)}
+              >
                 추가
               </Button>
             </div>

--- a/src/types/report/TPatchReport.ts
+++ b/src/types/report/TPatchReport.ts
@@ -1,0 +1,24 @@
+import type { TCommonResponse } from '@/types/common';
+
+// PATCH /api/users/me/reports 요청 — 기존 성적표에 수강 이력을 수동으로 추가
+export type TPatchReportCourse = {
+  semester: string; // 학기 (예: 2023-1)
+  courseType: string; // 이수 구분
+  areaName?: string; // 이수 영역 (선택)
+  courseCode: string; // 학수번호
+  courseName: string; // 교과목명
+  credits: number; // 학점
+  grade: string; // 성적 (A+, A0, ... P, NP)
+  retake: boolean; // 재수강 여부
+};
+
+export type TPatchReportRequest = {
+  courses: TPatchReportCourse[];
+};
+
+// 응답 result: 새로 생성된 수강 이력 ID 목록
+export type TPatchReportResult = {
+  addedIds: number[];
+};
+
+export type TPatchReportResponse = TCommonResponse<TPatchReportResult>;


### PR DESCRIPTION
## 📋 작업 내용
- 학업 정보 화면에서 학기별로 추가한 수강 이력을 한 번에 저장(PATCH)하도록 연동

## 🎯 관련 이슈
- closes #50 

## 📝 변경 사항
- patchReportCourses API와 useAddCourses 훅·요청/응답 타입 추가
- 수정하기 버튼에 추가행 평탄화 후 PATCH 연결
- 전송 전 클라이언트 검증(필수항목·학점 0 이상·성적 enum, 이수영역 선택)
- 성공 시 리포트·졸업 판정 캐시 무효화 및 추가행 초기화, 에러 코드별 분기
 
## 📸 스크린샷 (선택사항)
<!--
필요한 경우 스크린샷 첨부
-->
