### PR TITLE
[Fix] deploy homeserver from dev branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to homeserver
 
 on:
   push:
-    branches: [main]
+    branches: [dev]
     paths:
       - "src/**"
       - "public/**"
@@ -31,7 +31,7 @@ jobs:
         run: |
           cd "$REPO_DIR"
           git fetch --all --prune
-          git reset --hard origin/main
+          git reset --hard origin/dev
 
       - name: Build frontend
         run: |


### PR DESCRIPTION
## Summary
- run homeserver deployment workflow on dev pushes
- sync the deployed checkout from origin/dev instead of origin/main

This makes dev merges deploy immediately to the homeserver.