### PR TITLE
[Fix] QA 반영

### DIFF
--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -33,8 +33,11 @@ axiosInstance.interceptors.response.use(
       return Promise.reject(error);
     }
 
+    // 재시도 요청임을 먼저 표시한다. (동시에 401난 여러 요청이 각자 refresh를 다시 트리거하지 않도록,
+    // refreshPromise 생성 여부와 무관하게 모든 요청에 _retry를 찍는다)
+    originalRequest._retry = true;
+
     if (!refreshPromise) {
-      originalRequest._retry = true;
       refreshPromise = axios
         .post(`${import.meta.env.VITE_API_URL}/auth/refresh`, {}, { withCredentials: true })
         .then(({ data }) => {

--- a/src/apis/report/report.ts
+++ b/src/apis/report/report.ts
@@ -1,5 +1,5 @@
 import axiosInstance from '@/apis/axiosInstance';
-import type { TCourseName } from '@/types/course';
+import type { TCourseType } from '@/types/course';
 import type { TGetReportDetailResponse } from '@/types/report/TGetReportDetail';
 import type { TGetReportSummaryResponse } from '@/types/report/TGetReportSummary';
 import type { TGetUserReportsResponse } from '@/types/report/TGetUserReports';
@@ -19,7 +19,7 @@ export const getReportSummary = async () => {
 };
 
 // courseType별 영역 상세 조회. 잘못된 courseType은 400(COMMON400_1).
-export const getReportDetail = async (courseType: TCourseName) => {
+export const getReportDetail = async (courseType: TCourseType) => {
   const { data } = await axiosInstance.get<TGetReportDetailResponse>('/api/reports', { params: { courseType } });
   return data.result;
 };

--- a/src/components/common/errorBoundary.tsx
+++ b/src/components/common/errorBoundary.tsx
@@ -1,0 +1,54 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+import Warning from '@/assets/icons/warning.svg?react';
+import Button from '@/components/common/button';
+
+interface IErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface IErrorBoundaryState {
+  hasError: boolean;
+}
+
+// 렌더링 중 발생한 예외로 앱 전체가 흰 화면이 되는 것을 막는 전역 에러 경계.
+// (에러 경계는 클래스 컴포넌트로만 구현 가능)
+export default class ErrorBoundary extends Component<IErrorBoundaryProps, IErrorBoundaryState> {
+  state: IErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): IErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    // 추후 에러 로깅(Sentry 등) 연동 지점
+    console.error('Unhandled error:', error, info);
+  }
+
+  handleGoHome = () => {
+    // 라우터 컨텍스트 밖이므로 전체 리로드로 홈으로 이동한다.
+    window.location.href = '/';
+  };
+
+  render() {
+    const { hasError } = this.state;
+    const { children } = this.props;
+
+    if (hasError) {
+      return (
+        <div className="min-h-dvh flex flex-col items-center justify-center gap-12">
+          <Warning className="w-20 h-20" />
+          <div className="flex flex-col items-center gap-1">
+            <p className="text-coolgray-90 text-heading-2">문제가 발생했어요</p>
+            <p className="text-coolgray-60 text-body-l">잠시 후 다시 시도해주세요.</p>
+          </div>
+          <Button variant="outlined" className="w-40" onClick={this.handleGoHome}>
+            홈으로
+          </Button>
+        </div>
+      );
+    }
+
+    return children;
+  }
+}

--- a/src/components/common/errorBoundary.tsx
+++ b/src/components/common/errorBoundary.tsx
@@ -9,15 +9,16 @@ interface IErrorBoundaryProps {
 
 interface IErrorBoundaryState {
   hasError: boolean;
+  error: Error | null;
 }
 
 // 렌더링 중 발생한 예외로 앱 전체가 흰 화면이 되는 것을 막는 전역 에러 경계.
 // (에러 경계는 클래스 컴포넌트로만 구현 가능)
 export default class ErrorBoundary extends Component<IErrorBoundaryProps, IErrorBoundaryState> {
-  state: IErrorBoundaryState = { hasError: false };
+  state: IErrorBoundaryState = { hasError: false, error: null };
 
-  static getDerivedStateFromError(): IErrorBoundaryState {
-    return { hasError: true };
+  static getDerivedStateFromError(error: Error): IErrorBoundaryState {
+    return { hasError: true, error };
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
@@ -31,17 +32,21 @@ export default class ErrorBoundary extends Component<IErrorBoundaryProps, IError
   };
 
   render() {
-    const { hasError } = this.state;
+    const { hasError, error } = this.state;
     const { children } = this.props;
 
     if (hasError) {
       return (
-        <div className="min-h-dvh flex flex-col items-center justify-center gap-12">
+        <div className="min-h-dvh flex flex-col items-center justify-center gap-12 p-10">
           <Warning className="w-20 h-20" />
           <div className="flex flex-col items-center gap-1">
             <p className="text-coolgray-90 text-heading-2">문제가 발생했어요</p>
             <p className="text-coolgray-60 text-body-l">잠시 후 다시 시도해주세요.</p>
           </div>
+          {/* 개발 환경에서만 실제 에러 메시지를 노출해 디버깅을 돕는다. */}
+          {import.meta.env.DEV && error && (
+            <pre className="max-w-2xl whitespace-pre-wrap text-body-s text-alert">{error.message}</pre>
+          )}
           <Button variant="outlined" className="w-40" onClick={this.handleGoHome}>
             홈으로
           </Button>

--- a/src/components/common/footer.tsx
+++ b/src/components/common/footer.tsx
@@ -1,17 +1,22 @@
 import { Link } from 'react-router-dom';
+import { toast } from 'sonner';
 
 import Github from '@/assets/github.svg?react';
 import Logo from '@/assets/logo.svg?react';
+import { KAKAO_CHAT_URL, READY_MESSAGE } from '@/constants/links';
 
-// TODO: 경로 수정 필요
+// 항목별 동작 구분: 실제 페이지(link), 외부 링크(external), 미개발 안내(toast).
 const NAV_ITEMS = [
-  { name: '졸업 판정', path: '/graduation' },
-  { name: '커리큘럼', path: '/curriculum' },
-  { name: '고객지원', path: '/' },
-  { name: '동그리 소개', path: '/' },
-  { name: '자주 묻는 질문', path: '/' },
-  { name: '개인정보처리방침', path: '/' },
-];
+  { name: '졸업 판정', type: 'link', path: '/graduation' },
+  { name: '커리큘럼', type: 'toast' },
+  { name: '고객지원', type: 'external', href: KAKAO_CHAT_URL },
+  { name: '동그리 소개', type: 'toast' },
+  { name: '자주 묻는 질문', type: 'toast' },
+  { name: '개인정보처리방침', type: 'toast' },
+] as const;
+
+// 모든 항목이 공유하는 스타일.
+const ITEM_CLASS = 'px-2 py-3 hover:text-primary-60 hover:cursor-pointer';
 
 export default function Footer() {
   return (
@@ -25,11 +30,30 @@ export default function Footer() {
         </a>
       </div>
       <div className="w-full flex items-center justify-center text-button-m text-coolgray-60 gap-5 border-t border-b border-coolgray-30 py-9">
-        {NAV_ITEMS.map((item) => (
-          <Link key={item.name} to={item.path} className="px-2 py-3 hover:text-primary-60 hover:cursor-pointer">
-            {item.name}
-          </Link>
-        ))}
+        {NAV_ITEMS.map((item) => {
+          // 실제 페이지로 연결.
+          if (item.type === 'link') {
+            return (
+              <Link key={item.name} to={item.path} className={ITEM_CLASS}>
+                {item.name}
+              </Link>
+            );
+          }
+          // 외부 링크(고객지원 카카오 채팅).
+          if (item.type === 'external') {
+            return (
+              <a key={item.name} href={item.href} target="_blank" rel="noreferrer" className={ITEM_CLASS}>
+                {item.name}
+              </a>
+            );
+          }
+          // 미개발 기능: 토스트로 준비 중임을 안내.
+          return (
+            <button key={item.name} type="button" onClick={() => toast(READY_MESSAGE)} className={ITEM_CLASS}>
+              {item.name}
+            </button>
+          );
+        })}
       </div>
       <p className="text-body-xs text-coolgray-60">Copyright 2026. Donggree All rights reserved.</p>
     </footer>

--- a/src/components/common/header.tsx
+++ b/src/components/common/header.tsx
@@ -1,13 +1,16 @@
 import { Link } from 'react-router-dom';
+import { toast } from 'sonner';
 
 import Headset from '@/assets/headset.svg?react';
 import Logo from '@/assets/logo.svg?react';
 import UserThumb from '@/assets/userThumb.svg?react';
+import { KAKAO_CHAT_URL, READY_MESSAGE } from '@/constants/links';
 
+// 졸업 판정만 실제 페이지로 연결하고, 커리큘럼은 아직 미개발이라 토스트로 안내한다.
 const NAV_ITEMS = [
-  { name: '졸업 판정', path: '/graduation' },
-  { name: '커리큘럼', path: '/curriculum' },
-];
+  { name: '졸업 판정', type: 'link', path: '/graduation' },
+  { name: '커리큘럼', type: 'toast' },
+] as const;
 
 export default function Header() {
   return (
@@ -18,19 +21,36 @@ export default function Header() {
             <Logo className="hover:cursor-pointer w-40 h-auto" />
           </Link>
           <div className="flex items-center gap-2 text-button-m">
-            {NAV_ITEMS.map((item) => (
-              <Link key={item.name} to={item.path} className="px-2 py-3 hover:text-primary-60 hover:cursor-pointer">
-                {item.name}
-              </Link>
-            ))}
+            {NAV_ITEMS.map((item) =>
+              item.type === 'link' ? (
+                <Link key={item.name} to={item.path} className="px-2 py-3 hover:text-primary-60 hover:cursor-pointer">
+                  {item.name}
+                </Link>
+              ) : (
+                // 미개발 기능: 토스트로 준비 중임을 안내한다.
+                <button
+                  key={item.name}
+                  type="button"
+                  onClick={() => toast(READY_MESSAGE)}
+                  className="px-2 py-3 hover:text-primary-60 hover:cursor-pointer"
+                >
+                  {item.name}
+                </button>
+              ),
+            )}
           </div>
         </div>
         <div className="flex items-center gap-8 text-body-m">
-          {/* TODO: 경로 수정 필요 */}
-          <Link to="/" className="flex items-center gap-2 py-3 hover:cursor-pointer">
+          {/* 고객지원: 카카오 채널 채팅으로 연결 */}
+          <a
+            href={KAKAO_CHAT_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="flex items-center gap-2 py-3 hover:cursor-pointer"
+          >
             <Headset className="w-5 h-5" />
             <span>고객지원</span>
-          </Link>
+          </a>
           <Link to="/my-page" className="flex items-center gap-2 hover:cursor-pointer">
             <UserThumb className="w-8 h-8" />
             <span>마이페이지</span>

--- a/src/components/common/select.tsx
+++ b/src/components/common/select.tsx
@@ -13,7 +13,7 @@ export default function Select({ options, placeholder = '선택', className = ''
     <div className="relative w-full">
       <select
         {...props}
-        value={value}
+        value={value ?? ''}
         className={`w-full appearance-none rounded-lg border border-coolgray-30 bg-white py-3 pl-2 pr-7 text-body-m text-coolgray-90 outline-none disabled:cursor-not-allowed disabled:bg-coolgray-10 disabled:text-coolgray-60 ${className}`}
       >
         <option value="" disabled>

--- a/src/components/common/select.tsx
+++ b/src/components/common/select.tsx
@@ -1,0 +1,39 @@
+interface ISelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
+  options: readonly string[];
+  placeholder?: string;
+}
+
+// 드롭다운 선택 입력. 값이 비어 있으면 placeholder 옵션이 보인다.
+// 네이티브 화살표를 숨기고(appearance-none) 커스텀 화살표를 칸 안쪽으로 들여 배치한다.
+export default function Select({ options, placeholder = '선택', className = '', value, ...props }: ISelectProps) {
+  // 현재 값이 고정 옵션에 없으면(기존 데이터의 비표준 값 등) 데이터 유실을 막기 위해 옵션에 포함한다.
+  const mergedOptions = typeof value === 'string' && value && !options.includes(value) ? [value, ...options] : options;
+
+  return (
+    <div className="relative w-full">
+      <select
+        {...props}
+        value={value}
+        className={`w-full appearance-none rounded-lg border border-coolgray-30 bg-white py-3 pl-2 pr-7 text-body-m text-coolgray-90 outline-none disabled:cursor-not-allowed disabled:bg-coolgray-10 disabled:text-coolgray-60 ${className}`}
+      >
+        <option value="" disabled>
+          {placeholder}
+        </option>
+        {mergedOptions.map((option) => (
+          <option key={option} value={option}>
+            {option}
+          </option>
+        ))}
+      </select>
+      <svg
+        className="pointer-events-none absolute right-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-coolgray-60"
+        viewBox="0 0 20 20"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+      >
+        <path d="M5 8l5 5 5-5" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    </div>
+  );
+}

--- a/src/components/common/toggle.tsx
+++ b/src/components/common/toggle.tsx
@@ -1,0 +1,25 @@
+interface IToggleProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+// iOS 스타일 토글 스위치. 켜짐=primary, 꺼짐=회색, 흰 손잡이가 슬라이드한다.
+export default function Toggle({ checked, onChange }: IToggleProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      onClick={() => onChange(!checked)}
+      className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full transition-colors ${
+        checked ? 'bg-primary-60' : 'bg-coolgray-30'
+      }`}
+    >
+      <span
+        className={`inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform ${
+          checked ? 'translate-x-5' : 'translate-x-0.5'
+        }`}
+      />
+    </button>
+  );
+}

--- a/src/components/courseSummaryCard.tsx
+++ b/src/components/courseSummaryCard.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
 
-import { COURSE_LABEL, type TCourseName } from '@/types/course';
+import { COURSE_LABEL, type TCourseType } from '@/types/course';
 
 interface ICourseSummaryCardProps {
-  courseName: TCourseName;
+  courseType: TCourseType;
   progress: number;
   remainingCredits: number;
   status: 'PASS' | 'FAIL';
@@ -11,7 +11,7 @@ interface ICourseSummaryCardProps {
 }
 
 export default function CourseSummaryCard({
-  courseName,
+  courseType,
   progress,
   remainingCredits,
   status,
@@ -30,11 +30,11 @@ export default function CourseSummaryCard({
   const circumference = 2 * Math.PI * radius;
   const arcLength = circumference * 0.75;
   const filledLength = arcLength * (animatedProgress / 100);
-  const gradientId = `highlight-${courseName}`;
+  const gradientId = `highlight-${courseType}`;
 
   return (
     <div className="border border-primary-60 p-4 flex flex-col gap-4 text-coolgray-90 rounded-sm">
-      <p className="text-heading-5">{COURSE_LABEL[courseName]}</p>
+      <p className="text-heading-5">{COURSE_LABEL[courseType]}</p>
       <div className="flex flex-col items-center">
         <svg viewBox="0 0 100 100" className="w-50 h-50">
           <defs>

--- a/src/components/courseTabView.tsx
+++ b/src/components/courseTabView.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import AreaDetailCard from '@/components/areaDetailCard';
 import type { TChipVariant } from '@/components/chip';
 import useReportDetail from '@/hooks/report/useReportDetail';
-import { COURSE_LABEL, type TCourseName } from '@/types/course';
+import { COURSE_LABEL, type TCourseType } from '@/types/course';
 import type { TReportItemStatus } from '@/types/report/TGetReportDetail';
 
 // 과목 이수 상태 → 칩 variant 매핑
@@ -15,11 +15,11 @@ const STATUS_TO_CHIP: Record<TReportItemStatus, TChipVariant> = {
 
 interface ICourseTabViewProps {
   // summary의 areaOverviews에서 받은, 이 회원에게 적용되는 영역 탭 목록
-  courseTypes: TCourseName[];
+  courseTypes: TCourseType[];
 }
 
 export default function CourseTabView({ courseTypes }: ICourseTabViewProps) {
-  const [activeTab, setActiveTab] = useState<TCourseName>(courseTypes[0] ?? 'COMMON_GENERAL');
+  const [activeTab, setActiveTab] = useState<TCourseType>(courseTypes[0] ?? 'COMMON_GENERAL');
   // 활성 탭의 courseType으로만 상세를 조회한다(지연 로딩, 탭별 캐시).
   const { data, isPending, isError } = useReportDetail(activeTab);
 

--- a/src/components/onBoardingModal.tsx
+++ b/src/components/onBoardingModal.tsx
@@ -4,23 +4,7 @@ import Button from '@/components/common/button';
 import TextField from '@/components/common/textField';
 import useOnboarding from '@/hooks/auth/useOnboarding';
 import { useModalStore } from '@/stores/modalStore';
-
-// 클라이언트 입력 검증 (서버 규칙과 동일하게 맞춘다)
-// 이름: 필수, 5자 이하 / 학번: 필수, 숫자 10자리
-// blur/입력 중과 제출 시 결과가 일치하도록 검증 함수 내부에서 먼저 trim한 뒤 검사한다.
-const validateName = (value: string): string => {
-  const trimmed = value.trim();
-  if (!trimmed) return '*이름을 입력해주세요.';
-  if (trimmed.length > 5) return '*이름은 5자 이하로 입력해주세요.';
-  return '';
-};
-
-const validateStudentId = (value: string): string => {
-  const trimmed = value.trim();
-  if (!trimmed) return '*학번을 입력해주세요.';
-  if (!/^\d{10}$/.test(trimmed)) return '*학번은 숫자 10자리로 입력해주세요.';
-  return '';
-};
+import { validateName, validateStudentId } from '@/utils/validators';
 
 export default function OnBoardingModal() {
   const { type, closeModal } = useModalStore();

--- a/src/constants/errorCodes.ts
+++ b/src/constants/errorCodes.ts
@@ -1,0 +1,9 @@
+// 서버 응답 봉투의 에러 코드 중, 프론트에서 분기에 사용하는 것만 의미 있는 이름으로 모은다.
+export const ERROR_CODE = {
+  ALREADY_ONBOARDED: 'USER409_1', // 이미 온보딩이 완료된 회원
+  DUPLICATE_STUDENT_ID: 'USER409_2', // 이미 사용 중인 학번
+  IDENTITY_LOCKED: 'USER409_3', // 본인 인증 후 학번/이름 변경 불가
+  INVALID_GRADE: 'TRANSCRIPT400_4', // 허용되지 않은 이수구분/성적 값
+  NO_GRADUATION_REPORT: 'GRADUATION404_1', // 학업 리포트 없음
+  NO_REQUIREMENT: 'GRADUATION404_2', // 적용 가능한 졸업 요건 없음
+} as const;

--- a/src/constants/links.ts
+++ b/src/constants/links.ts
@@ -1,0 +1,7 @@
+// 외부 링크 및 공용 안내 문구 상수.
+
+// 고객지원: 카카오 채널 채팅 주소.
+export const KAKAO_CHAT_URL = 'http://pf.kakao.com/_UxnFGX/chat';
+
+// 아직 개발되지 않은 기능 클릭 시 보여줄 토스트 문구.
+export const READY_MESSAGE = '준비 중인 기능입니다.';

--- a/src/constants/querykeys/queryKeys.ts
+++ b/src/constants/querykeys/queryKeys.ts
@@ -1,6 +1,8 @@
 export const QUERY_KEYS = {
   GET_USER_INFO: ['users', 'me'] as const,
   GET_USER_REPORTS: ['users', 'me', 'reports'] as const,
+  // 졸업 판정 리포트(요약·영역상세)를 한 번에 무효화하기 위한 접두사 키.
+  REPORTS_ROOT: ['reports'] as const,
   GET_REPORT_SUMMARY: ['reports', 'summary'] as const,
   GET_REPORT_BY_COURSE_TYPE: (courseType: string) => ['reports', { courseType }] as const,
 } as const;

--- a/src/hooks/auth/useOnboarding.ts
+++ b/src/hooks/auth/useOnboarding.ts
@@ -3,11 +3,13 @@ import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 
 import { postOnboarding } from '@/apis/auth/auth';
+import { ERROR_CODE } from '@/constants/errorCodes';
 import { QUERY_KEYS } from '@/constants/querykeys/queryKeys';
 import { useCoreMutation } from '@/hooks/customQuery';
 import { useModalStore } from '@/stores/modalStore';
 import type { TPostOnboardingRequest } from '@/types/auth/TPostOnboarding';
 import type { TResponseError } from '@/types/common';
+import { getErrorCode, getErrorMessage } from '@/utils/error';
 
 // 온보딩 정보 저장 훅
 // 성공 시 사용자 정보 캐시를 무효화하고(온보딩 완료 반영) 홈으로 이동시킨다.
@@ -23,23 +25,23 @@ export default function useOnboarding() {
       navigate('/');
     },
     onError: (error: TResponseError) => {
-      const code = error.response?.data?.code;
+      const code = getErrorCode(error);
 
       // 이미 온보딩 완료된 회원(다른 탭에서 먼저 완료한 레이스 등): 입력을 저장하지 않고 모달을 닫은 뒤 홈으로 보낸다.
-      if (code === 'USER409_1') {
+      if (code === ERROR_CODE.ALREADY_ONBOARDED) {
         closeModal();
         navigate('/');
         return;
       }
 
       // 학번 중복은 제출 시점에만 알 수 있으므로 토스트로 안내한다.
-      if (code === 'USER409_2') {
+      if (code === ERROR_CODE.DUPLICATE_STUDENT_ID) {
         toast.error('이미 가입한 학번입니다.');
         return;
       }
 
       // 그 외(회원 없음 등 예기치 못한 경우)는 서버 메시지를 토스트로 안내한다.
-      toast.error(error.response?.data?.message ?? '온보딩 처리 중 오류가 발생했어요.');
+      toast.error(getErrorMessage(error) ?? '온보딩 처리 중 오류가 발생했어요.');
     },
   });
 }

--- a/src/hooks/customQuery.ts
+++ b/src/hooks/customQuery.ts
@@ -9,6 +9,7 @@ import {
 import { toast } from 'sonner';
 
 import type { TResponseError, TUseMutationCustomOptions, TUseQueryCustomOptions } from '@/types/common';
+import { getErrorStatus } from '@/utils/error';
 
 export function useCoreQuery<TQueryFnData, TData = TQueryFnData>(
   keyName: QueryKey,
@@ -23,7 +24,7 @@ export function useCoreQuery<TQueryFnData, TData = TQueryFnData>(
     // 특히 401은 이미 axios 인터셉터가 refresh를 시도한 "최종 실패"라 여기서 또 재시도할 이유가 없다.
     // 서버 오류(5xx)·네트워크 오류 같은 일시적 실패만 기존처럼 최대 3회 재시도한다.
     retry: (failureCount, error) => {
-      const status = (error as TResponseError)?.response?.status;
+      const status = getErrorStatus(error);
       if (status && status >= 400 && status < 500) return false;
       return failureCount < 3;
     },

--- a/src/hooks/report/useAddCourses.ts
+++ b/src/hooks/report/useAddCourses.ts
@@ -3,10 +3,12 @@ import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 
 import { patchReportCourses } from '@/apis/report/report';
+import { ERROR_CODE } from '@/constants/errorCodes';
 import { QUERY_KEYS } from '@/constants/querykeys/queryKeys';
 import { useCoreMutation } from '@/hooks/customQuery';
 import type { TResponseError } from '@/types/common';
 import type { TPatchReportRequest } from '@/types/report/TPatchReport';
+import { getErrorCode, getErrorMessage, getErrorStatus } from '@/utils/error';
 
 // 수강 이력 수동 추가 훅.
 // 성공 시 학업 리포트와 졸업 판정 캐시를 무효화하고 안내 토스트를 띄운다.
@@ -19,25 +21,22 @@ export default function useAddCourses() {
       // 수강 이력이 바뀌었으므로 성적표 조회와 졸업 판정(요약·영역상세) 캐시를 무효화한다.
       // ['reports'] 접두사로 요약(['reports','summary'])·영역상세(['reports',{courseType}])를 한 번에 무효화한다.
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.GET_USER_REPORTS });
-      queryClient.invalidateQueries({ queryKey: ['reports'] });
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.REPORTS_ROOT });
       toast.success('수강 이력이 추가되었어요.');
     },
     onError: (error: TResponseError) => {
-      const status = error.response?.status;
-      const code = error.response?.data?.code;
-
       // 성적표가 없으면(404 TRANSCRIPT404_1) 업로드로 유도.
-      if (status === 404) {
+      if (getErrorStatus(error) === 404) {
         navigate('/upload', { replace: true });
         return;
       }
       // 허용되지 않은 성적 값.
-      if (code === 'TRANSCRIPT400_4') {
+      if (getErrorCode(error) === ERROR_CODE.INVALID_GRADE) {
         toast.error('성적 값이 올바르지 않아요. (예: A+, B0, P)');
         return;
       }
       // 그 외(필수 누락 등)는 서버 메시지를 토스트로 안내.
-      toast.error(error.response?.data?.message ?? '수강 이력 추가 중 오류가 발생했어요.');
+      toast.error(getErrorMessage(error) ?? '수강 이력 추가 중 오류가 발생했어요.');
     },
   });
 }

--- a/src/hooks/report/useReportDetail.ts
+++ b/src/hooks/report/useReportDetail.ts
@@ -1,11 +1,11 @@
 import { getReportDetail } from '@/apis/report/report';
 import { QUERY_KEYS } from '@/constants/querykeys/queryKeys';
 import { useCoreQuery } from '@/hooks/customQuery';
-import type { TCourseName } from '@/types/course';
+import type { TCourseType } from '@/types/course';
 
 // courseType별 영역 상세 조회 훅.
 // 탭뷰에서 활성 탭의 courseType으로만 호출되어, 활성 탭 데이터만 조회한다(지연 로딩).
 // courseType이 queryKey에 포함되므로 탭별로 캐시되어 재방문 시 즉시 표시된다.
-export default function useReportDetail(courseType: TCourseName) {
+export default function useReportDetail(courseType: TCourseType) {
   return useCoreQuery(QUERY_KEYS.GET_REPORT_BY_COURSE_TYPE(courseType), () => getReportDetail(courseType));
 }

--- a/src/hooks/report/useUpdateCourses.ts
+++ b/src/hooks/report/useUpdateCourses.ts
@@ -10,19 +10,19 @@ import type { TResponseError } from '@/types/common';
 import type { TPatchReportRequest } from '@/types/report/TPatchReport';
 import { getErrorCode, getErrorMessage, getErrorStatus } from '@/utils/error';
 
-// 수강 이력 수동 추가 훅.
-// 성공 시 학업 리포트와 졸업 판정 캐시를 무효화하고 안내 토스트를 띄운다.
-export default function useAddCourses() {
+// 수강 이력 전체 치환(수정·추가·삭제) 훅.
+// 성공 시 학업 리포트와 졸업 판정 캐시를 무효화한다. (재조회로 재계산된 학점·평점·수정일까지 최신화)
+export default function useUpdateCourses() {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
 
   return useCoreMutation((body: TPatchReportRequest) => patchReportCourses(body), {
     onSuccess: () => {
-      // 수강 이력이 바뀌었으므로 성적표 조회와 졸업 판정(요약·영역상세) 캐시를 무효화한다.
-      // ['reports'] 접두사로 요약(['reports','summary'])·영역상세(['reports',{courseType}])를 한 번에 무효화한다.
+      // 수강 이력이 바뀌면 totalCredits·gpa·updatedAt도 재계산되므로 조회를 재실행한다.
+      // ['reports'] 접두사로 졸업 판정 요약(['reports','summary'])·영역상세(['reports',{courseType}])도 함께 무효화한다.
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.GET_USER_REPORTS });
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.REPORTS_ROOT });
-      toast.success('수강 이력이 추가되었어요.');
+      toast.success('수강 이력이 수정되었어요.');
     },
     onError: (error: TResponseError) => {
       // 성적표가 없으면(404 TRANSCRIPT404_1) 업로드로 유도.
@@ -36,7 +36,7 @@ export default function useAddCourses() {
         return;
       }
       // 그 외(필수 누락 등)는 서버 메시지를 토스트로 안내.
-      toast.error(getErrorMessage(error) ?? '수강 이력 추가 중 오류가 발생했어요.');
+      toast.error(getErrorMessage(error) ?? '수강 이력 수정 중 오류가 발생했어요.');
     },
   });
 }

--- a/src/hooks/report/useUploadTranscript.ts
+++ b/src/hooks/report/useUploadTranscript.ts
@@ -23,8 +23,9 @@ export default function useUploadTranscript() {
   return useCoreMutation((file: File) => putTranscript(file), {
     onSuccess: (data: TPutTranscriptResponse) => {
       // 성적표가 새로 저장됐으므로 관련 조회 캐시를 먼저 무효화한다. (어느 분기든 공통)
+      // ['reports'] 접두사로 졸업 판정 요약(['reports','summary'])과 영역상세(['reports',{courseType}])를 함께 무효화한다.
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.GET_USER_REPORTS });
-      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.GET_REPORT_SUMMARY });
+      queryClient.invalidateQueries({ queryKey: ['reports'] });
       // 업로드한 PDF의 학번/이름이 일치하면 서버가 그 시점에 본인 인증(identityVerified)을 자동 처리하므로,
       // 사용자 정보 캐시도 무효화해 최신 인증 상태가 반영되게 한다.
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.GET_USER_INFO });

--- a/src/hooks/report/useUploadTranscript.ts
+++ b/src/hooks/report/useUploadTranscript.ts
@@ -11,6 +11,7 @@ import { useCoreMutation } from '@/hooks/customQuery';
 import { useModalStore } from '@/stores/modalStore';
 import type { TResponseError } from '@/types/common';
 import type { TPutTranscriptResponse } from '@/types/report/TPutTranscript';
+import { getErrorCode, getErrorMessage, getErrorStatus } from '@/utils/error';
 
 // 성적표 PDF 업로드 훅.
 // 성공 시 관련 조회 캐시를 무효화하고 졸업 판정 화면으로 이동한다.
@@ -25,7 +26,7 @@ export default function useUploadTranscript() {
       // 성적표가 새로 저장됐으므로 관련 조회 캐시를 먼저 무효화한다. (어느 분기든 공통)
       // ['reports'] 접두사로 졸업 판정 요약(['reports','summary'])과 영역상세(['reports',{courseType}])를 함께 무효화한다.
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.GET_USER_REPORTS });
-      queryClient.invalidateQueries({ queryKey: ['reports'] });
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.REPORTS_ROOT });
       // 업로드한 PDF의 학번/이름이 일치하면 서버가 그 시점에 본인 인증(identityVerified)을 자동 처리하므로,
       // 사용자 정보 캐시도 무효화해 최신 인증 상태가 반영되게 한다.
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.GET_USER_INFO });
@@ -52,8 +53,8 @@ export default function useUploadTranscript() {
     },
     // either/or 정책상 onError를 직접 제공하므로 공용 기본 토스트는 뜨지 않는다. (중복 알림 방지)
     onError: (error: TResponseError) => {
-      const status = error.response?.status;
-      const code = error.response?.data?.code;
+      const status = getErrorStatus(error);
+      const code = getErrorCode(error);
 
       // 회원 조회 실패(404)·서버 내부 오류(500)는 사용자가 조치할 수 없으므로 NotFound로 보낸다.
       if (status === 404 || status === 500) {
@@ -76,7 +77,7 @@ export default function useUploadTranscript() {
       }
 
       // 그 외 예기치 못한 에러는 토스트로 안내한다. (예: 서버까지 전달된 파일 누락 등)
-      toast.error(error.response?.data?.message ?? '업로드 중 오류가 발생했습니다.');
+      toast.error(getErrorMessage(error) ?? '업로드 중 오류가 발생했습니다.');
     },
   });
 }

--- a/src/hooks/useInView.ts
+++ b/src/hooks/useInView.ts
@@ -1,26 +1,31 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
+// 요소가 뷰포트에 들어오면 isInView를 true로 만든다. (스크롤 진입 애니메이션용)
+// 콜백 ref를 사용해, 로딩 화면을 먼저 그렸다가 데이터 도착 후 콘텐츠가 뒤늦게 마운트되는 경우에도
+// ref가 실제로 붙는 시점에 옵저버를 설치한다. (effect 한 번만 실행되어 옵저버를 놓치는 문제 방지)
 export default function useInView(threshold = 0.2) {
-  const ref = useRef<HTMLDivElement>(null);
   const [isInView, setIsInView] = useState(false);
+  const observerRef = useRef<IntersectionObserver | null>(null);
 
-  useEffect(() => {
-    const element = ref.current;
-    if (!element) return;
+  const ref = useCallback(
+    (element: HTMLDivElement | null) => {
+      // 이전 요소에 대한 관찰을 정리한다. (재마운트·threshold 변경 대응)
+      observerRef.current?.disconnect();
+      if (!element) return;
 
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0]?.isIntersecting) {
-          setIsInView(true);
-          observer.unobserve(element);
-        }
-      },
-      { threshold },
-    );
-
-    observer.observe(element);
-    return () => observer.disconnect();
-  }, [threshold]);
+      observerRef.current = new IntersectionObserver(
+        (entries) => {
+          if (entries[0]?.isIntersecting) {
+            setIsInView(true);
+            observerRef.current?.disconnect();
+          }
+        },
+        { threshold },
+      );
+      observerRef.current.observe(element);
+    },
+    [threshold],
+  );
 
   return [ref, isInView] as const;
 }

--- a/src/hooks/user/useUpdateProfile.ts
+++ b/src/hooks/user/useUpdateProfile.ts
@@ -2,10 +2,12 @@ import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
 import { patchProfile } from '@/apis/user/user';
+import { ERROR_CODE } from '@/constants/errorCodes';
 import { QUERY_KEYS } from '@/constants/querykeys/queryKeys';
 import { useCoreMutation } from '@/hooks/customQuery';
 import type { TResponseError } from '@/types/common';
 import type { TPatchProfileRequest } from '@/types/user/TPatchProfile';
+import { getErrorCode, getErrorMessage } from '@/utils/error';
 
 // 프로필 수정 훅.
 // 성공 시 사용자 정보 캐시를 무효화하고 안내 토스트를 띄운다(페이지에 머문다).
@@ -19,20 +21,20 @@ export default function useUpdateProfile() {
       toast.success('프로필이 수정되었어요.');
     },
     onError: (error: TResponseError) => {
-      const code = error.response?.data?.code;
+      const code = getErrorCode(error);
 
       // 학번 중복은 제출 시점에만 알 수 있어 토스트로 안내.
-      if (code === 'USER409_2') {
+      if (code === ERROR_CODE.DUPLICATE_STUDENT_ID) {
         toast.error('이미 가입한 학번입니다.');
         return;
       }
       // 본인 인증 후 학번/이름 변경 시도 (UI에서 잠그지만 방어적 안내).
-      if (code === 'USER409_3') {
+      if (code === ERROR_CODE.IDENTITY_LOCKED) {
         toast.error('본인 인증 후에는 학번과 이름을 변경할 수 없어요.');
         return;
       }
       // 그 외(온보딩 미완료·회원 없음 등)는 서버 메시지를 토스트로 안내.
-      toast.error(error.response?.data?.message ?? '프로필 수정 중 오류가 발생했어요.');
+      toast.error(getErrorMessage(error) ?? '프로필 수정 중 오류가 발생했어요.');
     },
   });
 }

--- a/src/hooks/user/useUserInfo.ts
+++ b/src/hooks/user/useUserInfo.ts
@@ -6,5 +6,7 @@ import { useCoreQuery } from '@/hooks/customQuery';
 // 라우팅 게이트(인증/온보딩 판단)와 화면 표시에 함께 쓰이므로
 // data뿐 아니라 isPending/isError 등 query 상태 전체를 반환한다.
 export default function useUserInfo() {
-  return useCoreQuery(QUERY_KEYS.GET_USER_INFO, () => getUserInfo());
+  // 인증 게이트는 빠르게 판단해야 하므로 재시도하지 않는다.
+  // (네트워크/5xx 실패 시 3회 backoff를 기다리지 않고 즉시 에러 화면으로 분기 — 호출부에서 처리)
+  return useCoreQuery(QUERY_KEYS.GET_USER_INFO, () => getUserInfo(), { retry: false });
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,7 +18,8 @@ createRoot(document.getElementById('root')!).render(
       <QueryClientProvider client={queryClient}>
         <App />
         <Toaster position="top-center" richColors />
-        <ReactQueryDevtools initialIsOpen={false} />
+        {/* 개발 환경에서만 React Query Devtools를 렌더한다. (프로덕션 번들/노출 방지) */}
+        {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
       </QueryClientProvider>
     </ErrorBoundary>
   </StrictMode>,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,16 +6,20 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { Toaster } from 'sonner';
 
+import ErrorBoundary from '@/components/common/errorBoundary';
+
 import App from './App.tsx';
 
 const queryClient = new QueryClient();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <App />
-      <Toaster position="top-center" richColors />
-      <ReactQueryDevtools initialIsOpen={false} />
-    </QueryClientProvider>
+    <ErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <App />
+        <Toaster position="top-center" richColors />
+        <ReactQueryDevtools initialIsOpen={false} />
+      </QueryClientProvider>
+    </ErrorBoundary>
   </StrictMode>,
 );

--- a/src/pages/academicRecords.tsx
+++ b/src/pages/academicRecords.tsx
@@ -80,11 +80,15 @@ export default function AcademicRecords() {
   const { mutate: updateCourses, isPending: isSaving } = useUpdateCourses();
 
   // 조회 데이터로 편집 상태를 한 번 초기화한다. (이미 채웠으면 사용자의 편집을 덮어쓰지 않음)
-  // 수정 성공 후 재조회 시 다시 채울 수 있도록 onSuccess에서 seededRef를 리셋한다.
+  // 보기 모드에서는 항상 최신 서버 데이터와 동기화하고(백그라운드 리페치 반영),
+  // 편집 모드에서는 사용자의 입력을 덮어쓰지 않도록 진입 시 최초 1회만 시드한다.
+  // 저장하지 않고 편집을 끄면 보기 모드 동기화로 수정 사항이 자연스럽게 취소된다.
   // 로딩→콘텐츠 전환 시 빈 표가 잠깐 보이지 않도록 페인트 전(useLayoutEffect)에 시드한다.
   useLayoutEffect(() => {
-    if (!data || seededRef.current) return;
-    seededRef.current = true;
+    if (!data) return;
+    // 편집 모드에서 이미 시드를 마쳤다면 사용자의 편집을 보존한다.
+    if (editMode && seededRef.current) return;
+    seededRef.current = editMode;
     setSemesters(
       data.courses.map((semester) => ({
         id: nextId.current++,
@@ -101,7 +105,7 @@ export default function AcademicRecords() {
         })),
       })),
     );
-  }, [data]);
+  }, [data, editMode]);
 
   const hasCourses = semesters.some((semester) => semester.courses.length > 0);
 
@@ -196,12 +200,11 @@ export default function AcademicRecords() {
       };
     });
 
-    // 성공 시 시드 플래그를 리셋해, 재조회로 받은 최신 데이터로 폼을 다시 채우고 보기 모드로 돌아간다.
+    // 성공 시 보기 모드로 돌아간다. (시딩 effect가 보기 모드에서 재조회된 최신 데이터로 폼을 다시 채운다)
     updateCourses(
       { courses },
       {
         onSuccess: () => {
-          seededRef.current = false;
           setEditMode(false);
         },
       },

--- a/src/pages/academicRecords.tsx
+++ b/src/pages/academicRecords.tsx
@@ -1,21 +1,27 @@
-import { useRef, useState } from 'react';
+import { Fragment, useLayoutEffect, useRef, useState } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 
 import Edit from '@/assets/icons/edit.svg?react';
 import Button from '@/components/common/button';
 import Loading from '@/components/common/loading';
+import Select from '@/components/common/select';
 import TextField from '@/components/common/textField';
-import useAddCourses from '@/hooks/report/useAddCourses';
+import Toggle from '@/components/common/toggle';
+import useUpdateCourses from '@/hooks/report/useUpdateCourses';
 import useUserReports from '@/hooks/report/useUserReports';
 import useInView from '@/hooks/useInView';
 import NotFound from '@/pages/notFound';
-import type { TTranscriptRecord } from '@/types/report/TGetUserReports';
+import { formatDateTime } from '@/utils/date';
 import { getErrorStatus } from '@/utils/error';
 
-// 추가 수강 이력의 성적 허용값 (서버 enum과 동일)
+// 수강 이력의 성적 허용값 (서버 enum과 동일)
 const ALLOWED_GRADES = ['A+', 'A0', 'B+', 'B0', 'C+', 'C0', 'D+', 'D0', 'F', 'P', 'NP'];
 
+// 수강 이력의 이수구분 선택지 (고정 목록)
+const COURSE_TYPE_OPTIONS = ['전공', '공교', '일교', '학기', '자선'];
+
+// 편집용 수강 이력
 interface ICourse {
   category: string;
   courseCode: string;
@@ -26,23 +32,16 @@ interface ICourse {
   retake: string;
 }
 
-interface IAddedCourse extends ICourse {
-  id: number;
+interface IEditCourse extends ICourse {
+  id: number; // React key 및 식별용 클라이언트 id (서버 id는 치환 시 재부여되므로 사용하지 않음)
 }
 
-// API 수강 이력(TTranscriptRecord)을 화면 표시용(ICourse + id) 형태로 변환한다.
-// 기존 수강 표와 수동 추가 행이 공유하는 ICourse 구조에 맞춘다.
-// (이수영역 null → '-', 재수강 boolean → 'O'/'X')
-const toDisplayCourse = (record: TTranscriptRecord): IAddedCourse => ({
-  id: record.id,
-  category: record.courseType,
-  courseCode: record.courseCode,
-  courseName: record.courseName,
-  credits: record.credits,
-  grade: record.grade,
-  area: record.areaName ?? '-',
-  retake: record.retake ? 'O' : 'X',
-});
+// 학기 그룹 (학기 이름도 편집 가능)
+interface IEditSemester {
+  id: number;
+  name: string;
+  courses: IEditCourse[];
+}
 
 type TCourseField = keyof ICourse;
 
@@ -73,42 +72,104 @@ export default function AcademicRecords() {
   // 컨테이너 전체에 페이드인을 걸기 때문에, 수강 내역이 많아 화면보다 길어지면
   // 기본 threshold(0.2)로는 한 번에 20%가 안 보여 영영 켜지지 않는다. 조금이라도 보이면 켜지도록 0으로 둔다.
   const [ref, isInView] = useInView(0);
-  const [addedCourses, setAddedCourses] = useState<Record<string, IAddedCourse[]>>({});
+  const [editMode, setEditMode] = useState(false); // false: 읽기 전용 보기, true: 편집
+  const [semesters, setSemesters] = useState<IEditSemester[]>([]);
+  const seededRef = useRef(false);
   const nextId = useRef(0);
   const { data, isPending, isError, error } = useUserReports();
-  const { mutate: addCourses, isPending: isAdding } = useAddCourses();
+  const { mutate: updateCourses, isPending: isSaving } = useUpdateCourses();
 
-  const hasNewCourses = Object.values(addedCourses).some((courses) => courses.length > 0);
-
-  const handleAddCourse = (semester: string) => {
-    setAddedCourses((prev) => ({
-      ...prev,
-      [semester]: [...(prev[semester] ?? []), { ...EMPTY_COURSE, id: nextId.current++ }],
-    }));
-  };
-
-  const handleDeleteCourse = (semester: string, id: number) => {
-    setAddedCourses((prev) => ({
-      ...prev,
-      [semester]: (prev[semester] ?? []).filter((course) => course.id !== id),
-    }));
-  };
-
-  const handleNewCourseChange = (semester: string, id: number, field: keyof ICourse, value: string | number) => {
-    const parsed = field === 'credits' ? Number(value) || 0 : value;
-    setAddedCourses((prev) => ({
-      ...prev,
-      [semester]: (prev[semester] ?? []).map((course) => (course.id === id ? { ...course, [field]: parsed } : course)),
-    }));
-  };
-
-  // "수정하기": 학기별로 추가한 행을 검증한 뒤 한 번에 PATCH로 반영한다.
-  const handleSubmitCourses = () => {
-    // 학기별 추가행을 학기 정보와 함께 평탄화한다.
-    const flattened = Object.entries(addedCourses).flatMap(([semester, list]) =>
-      list.map((course) => ({ semester, course })),
+  // 조회 데이터로 편집 상태를 한 번 초기화한다. (이미 채웠으면 사용자의 편집을 덮어쓰지 않음)
+  // 수정 성공 후 재조회 시 다시 채울 수 있도록 onSuccess에서 seededRef를 리셋한다.
+  // 로딩→콘텐츠 전환 시 빈 표가 잠깐 보이지 않도록 페인트 전(useLayoutEffect)에 시드한다.
+  useLayoutEffect(() => {
+    if (!data || seededRef.current) return;
+    seededRef.current = true;
+    setSemesters(
+      data.courses.map((semester) => ({
+        id: nextId.current++,
+        name: semester.semester,
+        courses: semester.records.map((record) => ({
+          id: nextId.current++,
+          category: record.courseType,
+          courseCode: record.courseCode,
+          courseName: record.courseName,
+          credits: record.credits,
+          grade: record.grade,
+          area: record.areaName ?? '',
+          retake: record.retake ? 'O' : 'X',
+        })),
+      })),
     );
-    if (flattened.length === 0) return;
+  }, [data]);
+
+  const hasCourses = semesters.some((semester) => semester.courses.length > 0);
+
+  // 학기 추가/삭제/이름 변경
+  const handleAddSemester = () => {
+    setSemesters((prev) => [...prev, { id: nextId.current++, name: '', courses: [] }]);
+  };
+
+  const handleDeleteSemester = (semesterId: number) => {
+    setSemesters((prev) => prev.filter((semester) => semester.id !== semesterId));
+  };
+
+  const handleSemesterNameChange = (semesterId: number, name: string) => {
+    setSemesters((prev) => prev.map((semester) => (semester.id === semesterId ? { ...semester, name } : semester)));
+  };
+
+  // 학기 내 수강 행 추가/삭제/변경
+  const handleAddCourse = (semesterId: number) => {
+    setSemesters((prev) =>
+      prev.map((semester) =>
+        semester.id === semesterId
+          ? { ...semester, courses: [...semester.courses, { ...EMPTY_COURSE, id: nextId.current++ }] }
+          : semester,
+      ),
+    );
+  };
+
+  const handleDeleteCourse = (semesterId: number, courseId: number) => {
+    setSemesters((prev) =>
+      prev.map((semester) =>
+        semester.id === semesterId
+          ? { ...semester, courses: semester.courses.filter((course) => course.id !== courseId) }
+          : semester,
+      ),
+    );
+  };
+
+  const handleCourseChange = (semesterId: number, courseId: number, field: keyof ICourse, value: string | number) => {
+    const parsed = field === 'credits' ? Number(value) || 0 : value;
+    setSemesters((prev) =>
+      prev.map((semester) =>
+        semester.id === semesterId
+          ? {
+              ...semester,
+              courses: semester.courses.map((course) =>
+                course.id === courseId ? { ...course, [field]: parsed } : course,
+              ),
+            }
+          : semester,
+      ),
+    );
+  };
+
+  // "수정하기": 전체 수강 이력을 검증한 뒤 통째로 치환(PATCH)한다.
+  const handleSubmit = () => {
+    if (semesters.some((semester) => semester.courses.length > 0 && !semester.name.trim())) {
+      toast.error('학기 이름을 입력해주세요.');
+      return;
+    }
+
+    const flattened = semesters.flatMap((semester) =>
+      semester.courses.map((course) => ({ semester: semester.name.trim(), course })),
+    );
+    // 전체를 비울 수는 없다(서버 @NotEmpty).
+    if (flattened.length === 0) {
+      toast.error('최소 1개의 수강 이력이 필요해요.');
+      return;
+    }
 
     // 클라이언트 검증: 필수항목(이수구분·학수번호·교과목명·성적) 채움, 학점 0 이상, 성적 enum (이수영역은 선택)
     const isValid = flattened.every(({ course }) => {
@@ -117,17 +178,16 @@ export default function AcademicRecords() {
       return filled && course.credits >= 0 && ALLOWED_GRADES.includes(grade);
     });
     if (!isValid) {
-      toast.error('추가한 과목의 모든 항목을 올바르게 입력해주세요. (성적은 A+·B0·P 등)');
+      toast.error('모든 항목을 올바르게 입력해주세요. (성적은 A+·B0·P 등)');
       return;
     }
 
     const courses = flattened.map(({ semester, course }) => {
-      // 기존 데이터의 빈 영역은 '-'로 표시되므로, 빈값과 '-' 모두 areaName에서 제외한다.
       const trimmedArea = course.area.trim();
       return {
         semester,
         courseType: course.category.trim(),
-        ...(trimmedArea && trimmedArea !== '-' ? { areaName: trimmedArea } : {}),
+        ...(trimmedArea ? { areaName: trimmedArea } : {}),
         courseCode: course.courseCode.trim(),
         courseName: course.courseName.trim(),
         credits: course.credits,
@@ -136,8 +196,77 @@ export default function AcademicRecords() {
       };
     });
 
-    // 성공 시 추가행을 비운다. (무효화로 다시 받아온 데이터에서 기존 수강으로 합류)
-    addCourses({ courses }, { onSuccess: () => setAddedCourses({}) });
+    // 성공 시 시드 플래그를 리셋해, 재조회로 받은 최신 데이터로 폼을 다시 채우고 보기 모드로 돌아간다.
+    updateCourses(
+      { courses },
+      {
+        onSuccess: () => {
+          seededRef.current = false;
+          setEditMode(false);
+        },
+      },
+    );
+  };
+
+  // 편집 모드의 수강 행 셀: 이수구분·성적은 드롭다운, 재수강은 체크박스, 나머지는 텍스트 입력.
+  const renderEditField = (
+    col: (typeof COLUMNS)[number],
+    course: IEditCourse,
+    onFieldChange: (field: keyof ICourse, value: string) => void,
+  ) => {
+    if (col.key === 'retake') {
+      return (
+        <div className="flex justify-center">
+          <input
+            type="checkbox"
+            checked={course.retake === 'O'}
+            disabled={isSaving}
+            onChange={(e) => onFieldChange('retake', e.target.checked ? 'O' : 'X')}
+            className="h-4 w-4 accent-primary-60"
+          />
+        </div>
+      );
+    }
+    if (col.key === 'category') {
+      return (
+        <Select
+          options={COURSE_TYPE_OPTIONS}
+          placeholder="이수 구분"
+          value={course.category}
+          disabled={isSaving}
+          onChange={(e) => onFieldChange('category', e.target.value)}
+        />
+      );
+    }
+    if (col.key === 'grade') {
+      return (
+        <Select
+          options={ALLOWED_GRADES}
+          placeholder="성적"
+          value={course.grade}
+          disabled={isSaving}
+          onChange={(e) => onFieldChange('grade', e.target.value)}
+        />
+      );
+    }
+    return (
+      <TextField
+        className="!w-full"
+        placeholder={col.label}
+        value={course[col.key]}
+        disabled={isSaving}
+        onChange={(e) => onFieldChange(col.key, e.target.value)}
+        {...(col.key === 'credits' && { type: 'number', min: 0 })}
+      />
+    );
+  };
+
+  // 보기 모드의 수강 행 셀: 고정 텍스트(재수강만 비활성 체크박스).
+  const renderViewField = (col: (typeof COLUMNS)[number], course: IEditCourse) => {
+    if (col.key === 'retake') {
+      return <input type="checkbox" checked={course.retake === 'O'} disabled className="h-4 w-4 accent-primary-60" />;
+    }
+    return course[col.key];
   };
 
   // 성적표 조회 상태 처리: 로딩 → 공용 Loading, 미업로드(404) → 업로드 유도, 그 외 에러 → NotFound
@@ -151,17 +280,22 @@ export default function AcademicRecords() {
     return <NotFound />;
   }
 
-  const { meta, courses } = data;
+  const { meta } = data;
 
-  // 상단 기본 정보 항목. 부전공/복수전공은 값이 있을 때만(null이면 숨김) 한 줄씩 추가한다.
+  // 상단 기본 정보 항목(고정 텍스트). 지정 순서, 부전공/복수전공·단과대학은 값이 있을 때만 표시한다.
   const basicInfoItems: { label: string; value: string | number }[] = [
     { label: '교육과정 적용년도', value: meta.admissionYear },
-    { label: '학과', value: meta.department },
   ];
+  if (meta.collegeName) basicInfoItems.push({ label: '단과대학', value: meta.collegeName });
+  basicInfoItems.push({ label: '학과', value: meta.department });
   if (meta.subMajor1) basicInfoItems.push({ label: '부전공1', value: meta.subMajor1 });
   if (meta.subMajor2) basicInfoItems.push({ label: '부전공2', value: meta.subMajor2 });
   if (meta.dualMajor1) basicInfoItems.push({ label: '복수전공1', value: meta.dualMajor1 });
   if (meta.dualMajor2) basicInfoItems.push({ label: '복수전공2', value: meta.dualMajor2 });
+  basicInfoItems.push({ label: '학적 상태', value: meta.academicStatus });
+  basicInfoItems.push({ label: '이수 학기', value: `${meta.completedSemesters}학기` });
+  basicInfoItems.push({ label: '총 취득학점', value: `${meta.totalCredits}학점` });
+  basicInfoItems.push({ label: '평점 평균', value: meta.gpa });
 
   return (
     <div
@@ -170,26 +304,59 @@ export default function AcademicRecords() {
     >
       <div className="flex flex-col items-center gap-12">
         <Edit className="w-20 h-20" />
-        <p className="text-heading-2 text-coolgray-90">내 학업 정보 관리</p>
+        <div className="flex flex-col items-center gap-7">
+          <p className="text-heading-2 text-coolgray-90">내 학업 정보 관리</p>
+          {/* 보기/편집 토글 스위치 */}
+          <div className="flex items-center gap-2">
+            <span className="text-body-m text-primary-60">편집 모드</span>
+            <Toggle checked={editMode} onChange={setEditMode} />
+          </div>
+        </div>
       </div>
 
-      {/* 기본 정보 */}
+      {/* 최초 업로드일 / 마지막 수정일 (오른쪽 정렬) */}
+      <div className="w-full max-w-5xl flex flex-col items-end">
+        <p className="text-body-m text-coolgray-60">최초 업로드일: {formatDateTime(meta.createdAt)}</p>
+        <p className="text-body-m text-coolgray-60">마지막 수정일: {formatDateTime(meta.updatedAt)}</p>
+      </div>
+
+      {/* 기본 정보 (고정 텍스트) */}
       <div className={sectionStyles}>
         <p className="text-heading-3 text-coolgray-90">기본 정보</p>
-        <div className="flex w-full flex-col gap-3 px-20">
+        {/* 블록은 중앙 정렬, 값(2열)은 같은 시작점에서 왼쪽 정렬 */}
+        <div className="grid grid-cols-[auto_auto] gap-x-40 gap-y-3">
           {basicInfoItems.map(({ label, value }) => (
-            <div key={label} className="flex justify-between">
+            <Fragment key={label}>
               <span className="text-heading-5 text-coolgray-90">{label}</span>
               <span className="text-body-l text-coolgray-90">{value}</span>
-            </div>
+            </Fragment>
           ))}
         </div>
       </div>
 
-      {/* 학기별 수강 내역 */}
-      {courses.map((semesterData) => (
-        <div key={semesterData.semester} className={sectionStyles}>
-          <p className="text-heading-3 text-coolgray-90">{semesterData.semester}</p>
+      {/* 학기별 수강 내역 (보기: 고정 텍스트 / 편집: 입력) */}
+      {semesters.map((semester) => (
+        <div key={semester.id} className={sectionStyles}>
+          {editMode ? (
+            <div className="flex items-center gap-3">
+              <TextField
+                placeholder="학기 (예: 2024-1)"
+                value={semester.name}
+                disabled={isSaving}
+                onChange={(e) => handleSemesterNameChange(semester.id, e.target.value)}
+              />
+              <button
+                type="button"
+                disabled={isSaving}
+                className="cursor-pointer text-body-m text-coolgray-60 hover:text-primary-60 disabled:cursor-not-allowed disabled:opacity-50"
+                onClick={() => handleDeleteSemester(semester.id)}
+              >
+                ✕
+              </button>
+            </div>
+          ) : (
+            <p className="text-heading-3 text-coolgray-90">{semester.name}</p>
+          )}
           <div className="w-full">
             {/* 헤더 행 */}
             <div className="flex w-full border-b border-coolgray-20 py-3">
@@ -201,105 +368,88 @@ export default function AcademicRecords() {
               <div className="w-[4%]" />
             </div>
 
-            {/* 기존 수강 행 (API 데이터) */}
-            {semesterData.records.map(toDisplayCourse).map((course) => (
-              <div key={course.id} className="flex w-full items-center border-b border-coolgray-10 py-3">
+            {/* 수강 행 */}
+            {semester.courses.map((course) => (
+              <div key={course.id} className="flex w-full items-center border-b border-coolgray-10 py-2">
                 {COLUMNS.map((col) => (
-                  <div key={col.key} className={`${col.width} text-center text-body-l text-coolgray-90`}>
-                    {col.key === 'retake' ? (
-                      <input
-                        type="checkbox"
-                        checked={course.retake === 'O'}
-                        disabled
-                        className="h-4 w-4 accent-primary-60"
-                      />
-                    ) : (
-                      course[col.key]
-                    )}
-                  </div>
-                ))}
-                <div className="w-[4%]" />
-              </div>
-            ))}
-
-            {/* 추가된 수강 행 */}
-            {addedCourses[semesterData.semester]?.map((newCourse) => (
-              <div key={newCourse.id} className="flex w-full items-center border-b border-coolgray-10 py-2">
-                {COLUMNS.map((col) => (
-                  <div key={col.key} className={`${col.width} px-1`}>
-                    {col.key === 'retake' ? (
-                      <div className="flex justify-center">
-                        <input
-                          type="checkbox"
-                          checked={newCourse.retake === 'O'}
-                          disabled={isAdding}
-                          onChange={(e) =>
-                            handleNewCourseChange(
-                              semesterData.semester,
-                              newCourse.id,
-                              'retake',
-                              e.target.checked ? 'O' : 'X',
-                            )
-                          }
-                          className="h-4 w-4 accent-primary-60"
-                        />
-                      </div>
-                    ) : (
-                      <TextField
-                        className="!w-full"
-                        placeholder={col.label}
-                        value={newCourse[col.key]}
-                        disabled={isAdding}
-                        onChange={(e) =>
-                          handleNewCourseChange(semesterData.semester, newCourse.id, col.key, e.target.value)
-                        }
-                        {...(col.key === 'credits' && { type: 'number', min: 0 })}
-                      />
-                    )}
+                  <div
+                    key={col.key}
+                    className={editMode ? `${col.width} px-1` : `${col.width} text-center text-body-l text-coolgray-90`}
+                  >
+                    {editMode
+                      ? renderEditField(col, course, (field, value) =>
+                          handleCourseChange(semester.id, course.id, field, value),
+                        )
+                      : renderViewField(col, course)}
                   </div>
                 ))}
                 <div className="flex w-[4%] justify-center">
-                  <button
-                    type="button"
-                    disabled={isAdding}
-                    className="cursor-pointer text-body-m text-coolgray-60 hover:text-primary-60 disabled:cursor-not-allowed disabled:opacity-50"
-                    onClick={() => handleDeleteCourse(semesterData.semester, newCourse.id)}
-                  >
-                    ✕
-                  </button>
+                  {editMode && (
+                    <button
+                      type="button"
+                      disabled={isSaving}
+                      className="cursor-pointer text-body-m text-coolgray-60 hover:text-primary-60 disabled:cursor-not-allowed disabled:opacity-50"
+                      onClick={() => handleDeleteCourse(semester.id, course.id)}
+                    >
+                      ✕
+                    </button>
+                  )}
                 </div>
               </div>
             ))}
 
-            {/* 추가 버튼 */}
-            <div className="flex w-full justify-end py-3">
-              <Button
-                variant={isAdding ? 'disabled' : 'outlined'}
-                className="w-16 h-10"
-                disabled={isAdding}
-                onClick={() => handleAddCourse(semesterData.semester)}
-              >
-                추가
-              </Button>
-            </div>
+            {/* 추가 버튼 (편집 모드) */}
+            {editMode && (
+              <div className="flex w-full justify-end py-3">
+                <Button
+                  variant={isSaving ? 'disabled' : 'outlined'}
+                  className="w-16 h-10"
+                  disabled={isSaving}
+                  onClick={() => handleAddCourse(semester.id)}
+                >
+                  추가
+                </Button>
+              </div>
+            )}
           </div>
         </div>
       ))}
 
-      <p className="text-body-l text-coolgray-60">*수정한 정보를 기준으로 졸업 판정이 진행됩니다.</p>
+      {/* 새로운 학기 추가 (편집 모드, 오른쪽 정렬) */}
+      {editMode && (
+        <div className="w-full max-w-5xl flex justify-end">
+          <Button
+            variant={isSaving ? 'disabled' : 'primary'}
+            className="w-40"
+            disabled={isSaving}
+            onClick={handleAddSemester}
+          >
+            새로운 학기 추가
+          </Button>
+        </div>
+      )}
+
+      {editMode && (
+        <p className="text-body-l text-coolgray-60">
+          *수정한 정보를 기준으로 졸업 판정이 진행되므로, 추가한 수강 이력이 부정확한 경우 정확한 판정이 어려울 수
+          있습니다.
+        </p>
+      )}
 
       <div className="flex gap-4">
         <Button variant="outlined" className="w-40" onClick={() => navigate('/upload')}>
           PDF 새로 업로드하기
         </Button>
-        <Button
-          variant={hasNewCourses && !isAdding ? 'primary' : 'disabled'}
-          className="w-40"
-          disabled={!hasNewCourses || isAdding}
-          onClick={handleSubmitCourses}
-        >
-          수정하기
-        </Button>
+        {editMode && (
+          <Button
+            variant={hasCourses && !isSaving ? 'primary' : 'disabled'}
+            className="w-40"
+            disabled={!hasCourses || isSaving}
+            onClick={handleSubmit}
+          >
+            수정하기
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/src/pages/academicRecords.tsx
+++ b/src/pages/academicRecords.tsx
@@ -70,7 +70,9 @@ const EMPTY_COURSE: ICourse = {
 
 export default function AcademicRecords() {
   const navigate = useNavigate();
-  const [ref, isInView] = useInView();
+  // 컨테이너 전체에 페이드인을 걸기 때문에, 수강 내역이 많아 화면보다 길어지면
+  // 기본 threshold(0.2)로는 한 번에 20%가 안 보여 영영 켜지지 않는다. 조금이라도 보이면 켜지도록 0으로 둔다.
+  const [ref, isInView] = useInView(0);
   const [addedCourses, setAddedCourses] = useState<Record<string, IAddedCourse[]>>({});
   const nextId = useRef(0);
   const { data, isPending, isError, error } = useUserReports();

--- a/src/pages/academicRecords.tsx
+++ b/src/pages/academicRecords.tsx
@@ -11,6 +11,7 @@ import useUserReports from '@/hooks/report/useUserReports';
 import useInView from '@/hooks/useInView';
 import NotFound from '@/pages/notFound';
 import type { TTranscriptRecord } from '@/types/report/TGetUserReports';
+import { getErrorStatus } from '@/utils/error';
 
 // 추가 수강 이력의 성적 허용값 (서버 enum과 동일)
 const ALLOWED_GRADES = ['A+', 'A0', 'B+', 'B0', 'C+', 'C0', 'D+', 'D0', 'F', 'P', 'NP'];
@@ -142,7 +143,7 @@ export default function AcademicRecords() {
     return <Loading />;
   }
   if (isError) {
-    if (error.response?.status === 404) {
+    if (getErrorStatus(error) === 404) {
       return <Navigate to="/upload" replace />;
     }
     return <NotFound />;

--- a/src/pages/graduation.tsx
+++ b/src/pages/graduation.tsx
@@ -120,7 +120,7 @@ export default function Graduation() {
 
         {/* 전체 졸업요건 미충족 사유 (없으면 숨김). 졸업 판정 아래 중앙 정렬, 영역별 사유와 동일한 글씨 */}
         {summary.unsatisfiedReasons.length > 0 && (
-          <div className="flex flex-col items-center gap-1 mt-4">
+          <div className="flex flex-col items-center gap-1 mb-4">
             {summary.unsatisfiedReasons.map((reason) => (
               <span key={reason} className="text-button-m text-alert">
                 {reason}

--- a/src/pages/graduation.tsx
+++ b/src/pages/graduation.tsx
@@ -8,11 +8,13 @@ import Loading from '@/components/common/loading';
 import CourseSummaryCard from '@/components/courseSummaryCard';
 import CourseTabView from '@/components/courseTabView';
 import ProgressBar from '@/components/progressBar';
+import { ERROR_CODE } from '@/constants/errorCodes';
 import { TRANSCRIPT_ERROR_MODAL } from '@/constants/report/transcriptErrorModals';
 import useReportSummary from '@/hooks/report/useReportSummary';
 import useInView from '@/hooks/useInView';
 import NotFound from '@/pages/notFound';
 import { useModalStore } from '@/stores/modalStore';
+import { getErrorCode } from '@/utils/error';
 
 export default function Graduation() {
   const navigate = useNavigate();
@@ -25,10 +27,10 @@ export default function Graduation() {
   const [tabRef, tabInView] = useInView(0.1);
   const [buttonRef, buttonInView] = useInView();
 
-  const errorCode = isError ? error?.response?.data?.code : undefined;
+  const errorCode = isError ? getErrorCode(error) : undefined;
   // 적용 가능한 졸업 요건이 없는 학과(404 GRADUATION404_2)는 업로드의 미지원 학과 모달 문구를 재사용해 안내하고,
   // 확인 시 홈으로 보낸다.
-  const isUnsupportedDept = errorCode === 'GRADUATION404_2';
+  const isUnsupportedDept = errorCode === ERROR_CODE.NO_REQUIREMENT;
   useEffect(() => {
     if (!isUnsupportedDept) return;
     const modal = TRANSCRIPT_ERROR_MODAL.TRANSCRIPT400_3;
@@ -50,7 +52,7 @@ export default function Graduation() {
 
   if (isError) {
     // 리포트 없음(404_1)은 업로드로 유도(게이트 우회 등 방어).
-    if (errorCode === 'GRADUATION404_1') {
+    if (errorCode === ERROR_CODE.NO_GRADUATION_REPORT) {
       return <Navigate to="/upload" replace />;
     }
     // 미지원 학과(404_2)는 위 모달을 띄우는 동안 로딩을 보여준다.
@@ -141,7 +143,7 @@ export default function Graduation() {
           {areaOverviews.map((area) => (
             <CourseSummaryCard
               key={area.courseType}
-              courseName={area.courseType}
+              courseType={area.courseType}
               progress={area.achievementRate}
               remainingCredits={area.remainingCredits}
               status={area.satisfied ? 'PASS' : 'FAIL'}

--- a/src/pages/graduation.tsx
+++ b/src/pages/graduation.tsx
@@ -89,7 +89,7 @@ export default function Graduation() {
           <ProgressBar progress={summary.achievementRate} animate={summaryInView} />
           <span className="text-heading-5 text-shimmer">졸업까지 {summary.achievementRate}% 달성했어요!</span>
         </div>
-        <div className="w-full flex flex-col gap-3 px-115">
+        <div className="w-full max-w-md mx-auto flex flex-col gap-3">
           <div className="flex justify-between">
             <span className="text-heading-5 text-coolgray-90">이수 학점</span>
             <span className="text-heading-5 text-coolgray-90">{summary.earnedCredits}학점</span>
@@ -103,7 +103,7 @@ export default function Graduation() {
             <span className="text-heading-5 text-primary-60">{summary.remainingCredits}학점</span>
           </div>
         </div>
-        <div className="w-full flex flex-col gap-3 px-100">
+        <div className="w-full max-w-md mx-auto flex flex-col gap-3">
           <div className="w-full flex justify-between">
             <span className="text-heading-4 text-coolgray-90">총 평점 평균</span>
             <span className="text-heading-4 text-coolgray-90">{summary.gpa}</span>

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
 
 import User from '@/assets/icons/user.svg?react';
 import Warning from '@/assets/icons/warning.svg?react';
@@ -7,6 +8,7 @@ import Chip from '@/components/chip';
 import Button from '@/components/common/button';
 import Loading from '@/components/common/loading';
 import TextField from '@/components/common/textField';
+import { READY_MESSAGE } from '@/constants/links';
 import useInView from '@/hooks/useInView';
 import useDeleteAccount from '@/hooks/user/useDeleteAccount';
 import useUpdateProfile from '@/hooks/user/useUpdateProfile';
@@ -36,9 +38,6 @@ export default function Profile() {
   const [studentIdError, setStudentIdError] = useState('');
   const [touched, setTouched] = useState({ name: false, nickname: false, studentId: false });
 
-  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
-
   // 사용자 정보가 처음 도착하면 폼을 채운다. (이미 채웠으면 사용자의 편집을 덮어쓰지 않음)
   useEffect(() => {
     if (!data || seededRef.current) return;
@@ -47,13 +46,6 @@ export default function Profile() {
     setNickname(data.nickname ?? '');
     setStudentId(data.studentId ?? '');
   }, [data]);
-
-  // 프로필 이미지 미리보기 URL 정리 (메모리 누수 방지). 이미지 업로드는 별도 API가 없어 로컬 미리보기만 지원한다.
-  useEffect(() => {
-    return () => {
-      if (previewUrl) URL.revokeObjectURL(previewUrl);
-    };
-  }, [previewUrl]);
 
   // 입력 변경: 이미 검증이 시작된 필드는 실시간으로 에러를 갱신한다.
   const handleNameChange = (value: string) => {
@@ -122,18 +114,6 @@ export default function Profile() {
     });
   };
 
-  const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const selected = e.target.files?.[0];
-    if (selected && selected.type.startsWith('image/')) {
-      setPreviewUrl(URL.createObjectURL(selected));
-    }
-    e.target.value = '';
-  };
-
-  const handleImageDelete = () => {
-    setPreviewUrl(null);
-  };
-
   // 사용자 정보 조회 상태 처리
   if (isPending) {
     return <Loading />;
@@ -155,25 +135,12 @@ export default function Profile() {
       <div className="flex w-full items-center justify-center gap-15">
         <div className="flex flex-1 justify-end p-4">
           <div className="flex flex-col items-center gap-6">
-            {previewUrl ? (
-              <img src={previewUrl} alt="프로필 이미지" className="h-30 w-30 rounded-full object-cover" />
-            ) : (
-              <ProfileImage className="h-30 w-30" />
-            )}
+            <ProfileImage className="h-30 w-30" />
             <div className="flex flex-col items-center gap-2">
-              <input ref={fileInputRef} type="file" accept="image/*" className="hidden" onChange={handleImageUpload} />
-              <Button variant="outlined" className="w-30" onClick={() => fileInputRef.current?.click()}>
+              {/* 프로필 사진 변경: 업로드 API 미구현이라 준비 중 안내만 한다. */}
+              <Button variant="outlined" className="w-30" onClick={() => toast(READY_MESSAGE)}>
                 이미지 업로드
               </Button>
-              {previewUrl && (
-                <button
-                  type="button"
-                  className="text-body-s text-primary-60 underline cursor-pointer"
-                  onClick={handleImageDelete}
-                >
-                  삭제
-                </button>
-              )}
             </div>
           </div>
         </div>

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -13,29 +13,7 @@ import useUpdateProfile from '@/hooks/user/useUpdateProfile';
 import useUserInfo from '@/hooks/user/useUserInfo';
 import NotFound from '@/pages/notFound';
 import { useModalStore } from '@/stores/modalStore';
-
-// 클라이언트 입력 검증 (서버 규칙과 동일). 이름 ≤5, 학번 숫자 10자리, 닉네임 ≤8
-// blur/입력 중과 제출 시 결과가 일치하도록 검증 함수 내부에서 먼저 trim한 뒤 검사한다.
-const validateName = (value: string): string => {
-  const trimmed = value.trim();
-  if (!trimmed) return '*이름을 입력해주세요.';
-  if (trimmed.length > 5) return '*이름은 5자 이하로 입력해주세요.';
-  return '';
-};
-
-const validateStudentId = (value: string): string => {
-  const trimmed = value.trim();
-  if (!trimmed) return '*학번을 입력해주세요.';
-  if (!/^\d{10}$/.test(trimmed)) return '*학번은 숫자 10자리로 입력해주세요.';
-  return '';
-};
-
-const validateNickname = (value: string): string => {
-  const trimmed = value.trim();
-  if (!trimmed) return '*닉네임을 입력해주세요.';
-  if (trimmed.length > 8) return '*닉네임은 8자 이하로 입력해주세요.';
-  return '';
-};
+import { validateName, validateNickname, validateStudentId } from '@/utils/validators';
 
 export default function Profile() {
   const [ref, isInView] = useInView();

--- a/src/pages/serverError.tsx
+++ b/src/pages/serverError.tsx
@@ -23,7 +23,6 @@ export default function ServerError({ onRetry }: IServerErrorProps) {
       <div className="flex flex-col items-center gap-1">
         <p className="text-primary-60 text-heading-1">500</p>
         <p className="text-coolgray-90 text-heading-4">서버에 연결할 수 없어요.</p>
-        <p className="text-coolgray-60 text-body-l">잠시 후 다시 시도해주세요.</p>
       </div>
       <Button variant="outlined" className="w-40" onClick={handleRetry}>
         다시 시도

--- a/src/pages/serverError.tsx
+++ b/src/pages/serverError.tsx
@@ -1,0 +1,33 @@
+import Warning from '@/assets/icons/warning.svg?react';
+import Button from '@/components/common/button';
+
+interface IServerErrorProps {
+  // 다시 시도 동작 (보통 쿼리 refetch). 없으면 페이지를 새로고침한다.
+  onRetry?: () => void;
+}
+
+// 서버 연결 실패(응답 없는 네트워크 오류)·서버 내부 오류(5xx) 시 보여주는 화면.
+// NotFound와 동일한 레이아웃을 따른다.
+export default function ServerError({ onRetry }: IServerErrorProps) {
+  const handleRetry = () => {
+    if (onRetry) {
+      onRetry();
+    } else {
+      window.location.reload();
+    }
+  };
+
+  return (
+    <div className="w-full flex-1 flex flex-col items-center justify-center gap-12">
+      <Warning className="w-20 h-20" />
+      <div className="flex flex-col items-center gap-1">
+        <p className="text-primary-60 text-heading-1">500</p>
+        <p className="text-coolgray-90 text-heading-4">서버에 연결할 수 없어요.</p>
+        <p className="text-coolgray-60 text-body-l">잠시 후 다시 시도해주세요.</p>
+      </div>
+      <Button variant="outlined" className="w-40" onClick={handleRetry}>
+        다시 시도
+      </Button>
+    </div>
+  );
+}

--- a/src/pages/uploadPage.tsx
+++ b/src/pages/uploadPage.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from 'react';
+import { toast } from 'sonner';
 
 import Inbox from '@/assets/icons/inbox.svg?react';
 import Upload from '@/assets/icons/upload.svg?react';
@@ -90,7 +91,7 @@ export default function UploadPage() {
                     if (selected && selected.type === 'application/pdf') {
                       setFile(selected);
                     } else if (selected) {
-                      alert('PDF 파일만 업로드할 수 있습니다.');
+                      toast.error('PDF 파일만 업로드할 수 있습니다.');
                     }
                     e.target.value = '';
                   }}

--- a/src/routes/protectedRoute.tsx
+++ b/src/routes/protectedRoute.tsx
@@ -2,14 +2,16 @@ import { Navigate, Outlet, useLocation } from 'react-router-dom';
 
 import Loading from '@/components/common/loading';
 import useUserInfo from '@/hooks/user/useUserInfo';
+import ServerError from '@/pages/serverError';
 
 // 2단 라우팅 게이트.
-// 1) 인증 게이트: 사용자 정보 조회 실패(미인증) 시 로그인 화면으로 보낸다.
-//    (401이면 axios 인터셉터가 refresh를 시도하고, 그래도 실패하면 여기서 /login으로 처리)
+// 1) 인증 게이트: 사용자 정보 조회 실패 시 분기.
+//    - 응답 없음(서버 다운)·5xx → 에러 화면(미인증과 구분)
+//    - 4xx(미인증 등) → 로그인 화면 (401이면 axios 인터셉터가 refresh를 먼저 시도)
 // 2) 온보딩 게이트: 온보딩 미완료(studentId === null)면 무조건 온보딩 화면으로 강제하고,
 //    완료한 사용자가 온보딩 화면에 진입하면 홈으로 돌려보낸다.
 export default function ProtectedRoute() {
-  const { data, isPending, isError } = useUserInfo();
+  const { data, isPending, isError, error, refetch } = useUserInfo();
   const { pathname } = useLocation();
 
   // 인증 확인이 끝날 때까지 기존 공용 로딩 컴포넌트를 보여준다.
@@ -18,8 +20,13 @@ export default function ProtectedRoute() {
     return <Loading />;
   }
 
-  // 미인증: 로그인 화면으로.
   if (isError || !data) {
+    // 서버 다운(응답 없음)·서버 오류(5xx)는 로그인이 아니라 에러 화면으로 안내한다.
+    const status = error?.response?.status;
+    if (!status || status >= 500) {
+      return <ServerError onRetry={() => refetch()} />;
+    }
+    // 그 외(4xx, 미인증 등)는 로그인 화면으로.
     return <Navigate to="/login" replace />;
   }
 

--- a/src/routes/protectedRoute.tsx
+++ b/src/routes/protectedRoute.tsx
@@ -12,12 +12,13 @@ import { getErrorStatus } from '@/utils/error';
 // 2) 온보딩 게이트: 온보딩 미완료(studentId === null)면 무조건 온보딩 화면으로 강제하고,
 //    완료한 사용자가 온보딩 화면에 진입하면 홈으로 돌려보낸다.
 export default function ProtectedRoute() {
-  const { data, isPending, isError, error, refetch } = useUserInfo();
+  const { data, isPending, isError, error, refetch, isFetching } = useUserInfo();
   const { pathname } = useLocation();
 
   // 인증 확인이 끝날 때까지 기존 공용 로딩 컴포넌트를 보여준다.
   // (이 컴포넌트는 Layout의 Outlet 자리에 렌더되므로 Header/Footer 사이를 flex-1로 채운다)
-  if (isPending) {
+  // 에러 화면에서 "다시 시도"로 재요청이 진행 중일 때도 로딩을 보여준다.
+  if (isPending || (isError && isFetching)) {
     return <Loading />;
   }
 

--- a/src/routes/protectedRoute.tsx
+++ b/src/routes/protectedRoute.tsx
@@ -3,6 +3,7 @@ import { Navigate, Outlet, useLocation } from 'react-router-dom';
 import Loading from '@/components/common/loading';
 import useUserInfo from '@/hooks/user/useUserInfo';
 import ServerError from '@/pages/serverError';
+import { getErrorStatus } from '@/utils/error';
 
 // 2단 라우팅 게이트.
 // 1) 인증 게이트: 사용자 정보 조회 실패 시 분기.
@@ -22,7 +23,7 @@ export default function ProtectedRoute() {
 
   if (isError || !data) {
     // 서버 다운(응답 없음)·서버 오류(5xx)는 로그인이 아니라 에러 화면으로 안내한다.
-    const status = error?.response?.status;
+    const status = getErrorStatus(error);
     if (!status || status >= 500) {
       return <ServerError onRetry={() => refetch()} />;
     }

--- a/src/routes/reportGate.tsx
+++ b/src/routes/reportGate.tsx
@@ -3,6 +3,7 @@ import { Navigate, Outlet } from 'react-router-dom';
 import Loading from '@/components/common/loading';
 import useUserReports from '@/hooks/report/useUserReports';
 import NotFound from '@/pages/notFound';
+import ServerError from '@/pages/serverError';
 
 // 리포트(성적표) 존재 게이트.
 // ProtectedRoute(인증·온보딩) 통과 후, 성적표 유무로 한 번 더 분기한다.
@@ -11,18 +12,23 @@ import NotFound from '@/pages/notFound';
 // - 그 외 에러: NotFound
 // - 성적표 있음: 통과(졸업 판정 등 렌더)
 export default function ReportGate() {
-  const { isPending, isError, error } = useUserReports();
+  const { isPending, isError, error, refetch } = useUserReports();
 
   if (isPending) {
     return <Loading />;
   }
 
   if (isError) {
+    const status = error.response?.status;
     // 미업로드(404)는 정상 흐름이므로 업로드로 보낸다.
-    if (error.response?.status === 404) {
+    if (status === 404) {
       return <Navigate to="/upload" replace />;
     }
-    // 예기치 못한 오류는 NotFound로 처리한다.
+    // 서버 다운(응답 없음)·서버 오류(5xx)는 에러 화면으로 안내한다.
+    if (!status || status >= 500) {
+      return <ServerError onRetry={() => refetch()} />;
+    }
+    // 그 외 예기치 못한 오류는 NotFound로 처리한다.
     return <NotFound />;
   }
 

--- a/src/routes/reportGate.tsx
+++ b/src/routes/reportGate.tsx
@@ -4,6 +4,7 @@ import Loading from '@/components/common/loading';
 import useUserReports from '@/hooks/report/useUserReports';
 import NotFound from '@/pages/notFound';
 import ServerError from '@/pages/serverError';
+import { getErrorStatus } from '@/utils/error';
 
 // 리포트(성적표) 존재 게이트.
 // ProtectedRoute(인증·온보딩) 통과 후, 성적표 유무로 한 번 더 분기한다.
@@ -19,7 +20,7 @@ export default function ReportGate() {
   }
 
   if (isError) {
-    const status = error.response?.status;
+    const status = getErrorStatus(error);
     // 미업로드(404)는 정상 흐름이므로 업로드로 보낸다.
     if (status === 404) {
       return <Navigate to="/upload" replace />;

--- a/src/routes/reportGate.tsx
+++ b/src/routes/reportGate.tsx
@@ -13,9 +13,10 @@ import { getErrorStatus } from '@/utils/error';
 // - 그 외 에러: NotFound
 // - 성적표 있음: 통과(졸업 판정 등 렌더)
 export default function ReportGate() {
-  const { isPending, isError, error, refetch } = useUserReports();
+  const { isPending, isError, error, refetch, isFetching } = useUserReports();
 
-  if (isPending) {
+  // 최초 조회 중이거나, 에러 화면에서 "다시 시도"로 재요청이 진행 중일 때 로딩을 보여준다.
+  if (isPending || (isError && isFetching)) {
     return <Loading />;
   }
 

--- a/src/types/course.ts
+++ b/src/types/course.ts
@@ -1,6 +1,6 @@
-export type TCourseName = 'COMMON_GENERAL' | 'LIBERAL_ARTS' | 'ACADEMIC_FOUNDATION' | 'FIRST_MAJOR' | 'SECOND_MAJOR';
+export type TCourseType = 'COMMON_GENERAL' | 'LIBERAL_ARTS' | 'ACADEMIC_FOUNDATION' | 'FIRST_MAJOR' | 'SECOND_MAJOR';
 
-export const COURSE_NAMES: TCourseName[] = [
+export const COURSE_TYPES: TCourseType[] = [
   'COMMON_GENERAL',
   'LIBERAL_ARTS',
   'ACADEMIC_FOUNDATION',
@@ -8,7 +8,7 @@ export const COURSE_NAMES: TCourseName[] = [
   'SECOND_MAJOR',
 ];
 
-export const COURSE_LABEL: Record<TCourseName, string> = {
+export const COURSE_LABEL: Record<TCourseType, string> = {
   COMMON_GENERAL: '공통교양',
   LIBERAL_ARTS: '일반교양',
   ACADEMIC_FOUNDATION: '학문기초',

--- a/src/types/report/TGetReportSummary.ts
+++ b/src/types/report/TGetReportSummary.ts
@@ -1,5 +1,5 @@
 import type { TCommonResponse } from '@/types/common';
-import type { TCourseName } from '@/types/course';
+import type { TCourseType } from '@/types/course';
 
 // GET /api/reports/summary 응답 — 전체 졸업 달성률 요약 + courseType별 이수 현황
 
@@ -16,7 +16,7 @@ export type TReportSummary = {
 
 // 영역(courseType)별 개요 카드
 export type TAreaOverview = {
-  courseType: TCourseName; // COMMON_GENERAL, LIBERAL_ARTS, ...
+  courseType: TCourseType; // COMMON_GENERAL, LIBERAL_ARTS, ...
   courseTypeName: string; // 공통교양, 일반교양, ...
   achievementRate: number; // 해당 영역 달성률 (0~100)
   remainingCredits: number; // 해당 영역 잔여 학점

--- a/src/types/report/TGetUserReports.ts
+++ b/src/types/report/TGetUserReports.ts
@@ -5,7 +5,8 @@ import type { TCommonResponse } from '@/types/common';
 
 // 상단 메타 정보
 export type TReportMeta = {
-  admissionYear: number; // 입학년도
+  admissionYear: number; // 입학년도(교육과정 적용년도)
+  collegeName: string | null; // 소속 단과대학명 (학과 미등록 시 null)
   department: string; // 전공 학과명
   subMajor1: string | null; // 제1부전공 학과명 (없으면 null)
   subMajor2: string | null; // 제2부전공 학과명 (없으면 null)
@@ -15,6 +16,8 @@ export type TReportMeta = {
   totalCredits: number; // 총취득학점
   gpa: number; // 평점 평균
   completedSemesters: number; // 이수 학기 수
+  createdAt: string; // 성적표 최초 생성 시각 (ISO)
+  updatedAt: string; // 최종 수정 시각 (ISO)
 };
 
 // 개별 수강 이력

--- a/src/types/report/TPatchReport.ts
+++ b/src/types/report/TPatchReport.ts
@@ -1,6 +1,7 @@
 import type { TCommonResponse } from '@/types/common';
+import type { TSemesterCourses } from '@/types/report/TGetUserReports';
 
-// PATCH /api/users/me/reports 요청 — 기존 성적표에 수강 이력을 수동으로 추가
+// PATCH /api/users/me/reports 요청 — 변경 후의 전체 수강 이력 목록으로 통째 치환(수정·추가·삭제)
 export type TPatchReportCourse = {
   semester: string; // 학기 (예: 2023-1)
   courseType: string; // 이수 구분
@@ -16,9 +17,11 @@ export type TPatchReportRequest = {
   courses: TPatchReportCourse[];
 };
 
-// 응답 result: 새로 생성된 수강 이력 ID 목록
+// 응답 result: 재계산된 학점·평점 + 학기 오름차순으로 그룹핑한 전체 수강 이력(치환 후 id 새로 부여)
 export type TPatchReportResult = {
-  addedIds: number[];
+  totalCredits: number;
+  gpa: number;
+  courses: TSemesterCourses[];
 };
 
 export type TPatchReportResponse = TCommonResponse<TPatchReportResult>;

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,5 +1,7 @@
 // ISO 날짜 문자열을 'YYYY.MM.DD HH:MM'(로컬 시각) 형식으로 변환한다.
 export const formatDateTime = (iso: string): string => {
+  // 빈 문자열·null 등 falsy 값은 new Date가 1970-01-01 등으로 잘못 파싱할 수 있어 먼저 거른다.
+  if (!iso) return '';
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return '';
   const pad = (n: number) => String(n).padStart(2, '0');

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,7 @@
+// ISO 날짜 문자열을 'YYYY.MM.DD HH:MM'(로컬 시각) 형식으로 변환한다.
+export const formatDateTime = (iso: string): string => {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '';
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${date.getFullYear()}.${pad(date.getMonth() + 1)}.${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
+};

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,0 +1,15 @@
+import { isAxiosError } from 'axios';
+
+import type { TCommonResponse } from '@/types/common';
+
+// 응답 봉투의 의미 코드(code)를 안전하게 추출한다. (axios 에러가 아니거나 응답이 없으면 undefined)
+export const getErrorCode = (error: unknown): string | undefined =>
+  isAxiosError<TCommonResponse<null>>(error) ? error.response?.data?.code : undefined;
+
+// 응답 봉투의 메시지를 안전하게 추출한다.
+export const getErrorMessage = (error: unknown): string | undefined =>
+  isAxiosError<TCommonResponse<null>>(error) ? error.response?.data?.message : undefined;
+
+// HTTP 상태 코드를 안전하게 추출한다. (응답 없는 네트워크 에러면 undefined)
+export const getErrorStatus = (error: unknown): number | undefined =>
+  isAxiosError(error) ? error.response?.status : undefined;

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -1,0 +1,26 @@
+// 공통 입력 검증 (서버 규칙과 동일). blur·입력 중과 제출 시 결과가 일치하도록 내부에서 먼저 trim한다.
+// 위반 시 '*'로 시작하는 안내 문구를, 통과 시 빈 문자열을 반환한다.
+
+// 이름: 필수, 5자 이하
+export const validateName = (value: string): string => {
+  const trimmed = value.trim();
+  if (!trimmed) return '*이름을 입력해주세요.';
+  if (trimmed.length > 5) return '*이름은 5자 이하로 입력해주세요.';
+  return '';
+};
+
+// 학번: 필수, 숫자 10자리
+export const validateStudentId = (value: string): string => {
+  const trimmed = value.trim();
+  if (!trimmed) return '*학번을 입력해주세요.';
+  if (!/^\d{10}$/.test(trimmed)) return '*학번은 숫자 10자리로 입력해주세요.';
+  return '';
+};
+
+// 닉네임: 필수, 8자 이하
+export const validateNickname = (value: string): string => {
+  const trimmed = value.trim();
+  if (!trimmed) return '*닉네임을 입력해주세요.';
+  if (trimmed.length > 8) return '*닉네임은 8자 이하로 입력해주세요.';
+  return '';
+};


### PR DESCRIPTION
## 📋 작업 내용
- QA 과정에서 발견된 안정성·정확성 문제 수정과 UI/UX 개선을 반영.
- 인증/인터셉터/캐시 안정화, 코드 품질 정리, 데이터 페이지 흰 화면 수정, 내 학업 정보 관리 페이지 편집·보기 개편, 미개발 기능 안내까지 포함

## 🎯 관련 이슈
- closes #52 

## 📝 변경 사항
### 1. 안정성 개선 (인증·인터셉터·캐시·에러 화면)
- 인증 게이트: 서버 다운/5xx를 미인증으로 오판해 로그인으로 보내던 문제 → 네트워크·5xx는 ServerError 화면, 4xx만 로그인으로 분기
- fail-fast: useUserInfo가 실패 시 3회 backoff 후에야 분기하던 지연 → retry 끄고 즉시 분기
- refresh 재진입 버그: 동시 401 요청 중 두 번째 요청에 _retry가 안 찍혀 refresh가 중복 실행될 수 있던 문제 → 모든 재시도 요청에 _retry 선표시
- ServerError 페이지 추가: 서버 연결 실패/5xx 대응 화면(다시 시도 버튼)
- 전역 ErrorBoundary 추가: 렌더 중 예외 시 앱 전체가 흰 화면이 되던 문제 방어
- 캐시 무효화: 업로드 성공 시 영역상세(courseType) 캐시가 무효화되지 않아 탭이 옛 데이터로 남던 문제 → ['reports'] 접두사로 요약·영역상세 함께 무효화
- ReportGate도 네트워크/5xx는 ServerError로 일관 처리

### 2. 코드 품질·타입·운영 개선
- 입력 검증 함수 중복(온보딩·프로필) → utils/validators로 추출해 공유
- 에러코드 매직스트링 분산 → constants/errorCodes로 모으고 getErrorCode/Status/Message 헬퍼로 일원화
- customQuery의 error as TResponseError 캐스팅 제거 → getErrorStatus로 안전 추출
- 리포트 무효화의 원시 키 → QUERY_KEYS.REPORTS_ROOT 상수로 대체
- uploadPage의 네이티브 alert → 토스트로 통일
- 서버와 어긋나던 타입/prop명 정렬: TCourseName→TCourseType, courseName prop→courseType
- React Query Devtools를 개발 환경에서만 렌더

### 3. 데이터 페이지 흰 화면 수정
- useInView가 마운트 시 1회만 옵저버를 걸어, 로딩 후 늦게 붙는 콘텐츠 ref를 놓쳐 opacity-0로 남던 문제 → 콜백 ref 방식으로 변경해 DOM이 실제 붙는 시점에 옵저버 설치
- 고정 패딩을 mx-auto로 변경해 반응형 UX 개선

### 4. 내 학업 정보 관리 — 편집·보기 토글 개편
- 수강 이력 전체 치환 PATCH 연동(useUpdateCourses로 useAddCourses 대체): 파싱 행 포함 수정·추가·삭제 후 한 번에 저장, 성공 시 재조회로 재계산값 반영
- 보기/편집 토글: 기본은 고정 텍스트 보기(가독성↑), 편집 모드에서만 입력·행/학기 추가·삭제·수정
- 이수구분·성적 드롭다운 공용 Select 컴포넌트 추가(커스텀 화살표, 기존 비표준 값 유실 방지)
- 기본 정보에 meta 전체 필드 지정 순서·고정 텍스트 표시(단과대학·부/복수전공 null 숨김), 값 시작점 기준 정렬
- 최초 업로드일·마지막 수정일 표시(YYYY.MM.DD HH:MM), 날짜 포맷 유틸 formatDateTime 추가

### 5. 고객지원 연결 및 미개발 기능 안내
- 헤더·푸터 고객지원 → 카카오 채널 채팅 링크 연결
- 커리큘럼·동그리 소개·자주 묻는 질문·개인정보처리방침·프로필 사진 변경 → "준비 중인 기능입니다." 토스트
- 카카오 채팅 URL·안내 문구를 constants/links 상수로 분리

## 📸 스크린샷 (선택사항)
<!--
필요한 경우 스크린샷 첨부
-->
