### PR TITLE
[Fix] OAuth 콜백 경로를 /login/callback으로 변경

### DIFF
--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -3,7 +3,7 @@ import Logo from '@/assets/logo.svg?react';
 
 export default function Login() {
   // 카카오 로그인 시작: 백엔드의 Spring Security OAuth2 진입점으로 이동시킨다.
-  // 이후 콜백/토큰 발급은 백엔드가 처리하고 /auth/callback으로 돌아온다.
+  // 이후 콜백/토큰 발급은 백엔드가 처리하고 /login/callback으로 돌아온다.
   const handleKakaoLogin = () => {
     window.location.href = `${import.meta.env.VITE_API_URL}/oauth2/authorization/kakao`;
   };

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -18,7 +18,8 @@ import ReportGate from '@/routes/reportGate';
 export const router = createBrowserRouter([
   // 인증 없이 접근 가능한 라우트 (로그인, OAuth 콜백)
   { path: '/login', element: <Login /> },
-  { path: '/auth/callback', element: <AuthCallback /> },
+  // 콜백 경로는 /login/callback. (/auth/* 는 같은 도메인에서 백엔드로 라우팅되어 빨려들어가므로 피한다)
+  { path: '/login/callback', element: <AuthCallback /> },
   {
     path: '/',
     element: <Layout />,


### PR DESCRIPTION
## 📋 작업 내용
- OAuth 콜백 경로를 /login/callback으로 변경

## 🎯 관련 이슈
- closes #56 

## 📝 변경 사항
-같은 도메인에서 /auth/* 가 백엔드로 라우팅되어 프론트 콜백이 401 나던 문제 해결 -콜백 라우트 경로 /auth/callback → /login/callback 변경
-login 페이지 콜백 안내 주석 동기화

## 📸 스크린샷 (선택사항)
<!--
필요한 경우 스크린샷 첨부
-->
