### PR TITLE
[Feat] 관리자 과목 분류 관리 UI 및 API 연동 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to homeserver
 
 on:
   push:
-    branches: [dev]
+    branches: [main]
     paths:
       - "src/**"
       - "public/**"

--- a/src/apis/admin/courseClassification.ts
+++ b/src/apis/admin/courseClassification.ts
@@ -1,0 +1,42 @@
+import axiosInstance from '@/apis/axiosInstance';
+import type { TGetAdminAreaTypesResponse } from '@/types/admin/TGetAdminAreaTypes';
+import type {
+  TCourseClassificationFilters,
+  TGetCourseClassificationsResponse,
+} from '@/types/admin/TGetCourseClassifications';
+import type {
+  TCourseClassificationUpsertRequest,
+  TPutCourseClassificationsResponse,
+} from '@/types/admin/TPutCourseClassifications';
+
+const joinParam = <T extends string | number>(values?: T[]) => {
+  if (!values || values.length === 0) return undefined;
+  return values.join(',');
+};
+
+// 과목 분류 필터/폼의 이수 영역 선택지 조회.
+export const getAdminAreaTypes = async () => {
+  const { data } = await axiosInstance.get<TGetAdminAreaTypesResponse>('/api/admin/area-types');
+  return data.result;
+};
+
+// 과목 분류 다중 필터 조회. 백엔드는 반복 파라미터와 콤마 문자열을 모두 허용하므로 콤마 문자열로 직렬화한다.
+export const getAdminCourseClassifications = async (filters: TCourseClassificationFilters) => {
+  const { data } = await axiosInstance.get<TGetCourseClassificationsResponse>('/api/admin/course-classifications', {
+    params: {
+      areaTypeIds: joinParam(filters.areaTypeIds),
+      courseTypes: joinParam(filters.courseTypes),
+      years: joinParam(filters.years),
+    },
+  });
+  return data.result;
+};
+
+// 과목 분류 배치 업서트. 단일 항목 저장 UI에서도 API 스펙에 맞춰 items 배열로 보낸다.
+export const putAdminCourseClassifications = async (body: TCourseClassificationUpsertRequest) => {
+  const { data } = await axiosInstance.put<TPutCourseClassificationsResponse>(
+    '/api/admin/course-classifications',
+    body,
+  );
+  return data.result;
+};

--- a/src/components/admin/adminConfirmModal.tsx
+++ b/src/components/admin/adminConfirmModal.tsx
@@ -23,7 +23,7 @@ export default function AdminConfirmModal() {
   };
 
   return (
-    <div className="fixed inset-0 z-100 flex items-center justify-center bg-overlay px-6">
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-overlay px-6">
       <div className="flex w-full max-w-xl flex-col gap-8 rounded-2xl bg-white p-10 text-coolgray-90 shadow-xl">
         <div className="flex flex-col gap-3">
           <div className="flex flex-col gap-2">

--- a/src/components/admin/adminConfirmModal.tsx
+++ b/src/components/admin/adminConfirmModal.tsx
@@ -1,0 +1,49 @@
+import Button from '@/components/common/button';
+import { useModalStore } from '@/stores/modalStore';
+
+export default function AdminConfirmModal() {
+  const { confirmContent, closeModal, type } = useModalStore();
+
+  if (type !== 'confirm' || !confirmContent) return null;
+
+  const {
+    title,
+    action,
+    description,
+    details,
+    confirmText = '확인',
+    cancelText = '취소',
+    confirmVariant = 'primary',
+    onConfirm,
+  } = confirmContent;
+
+  const handleConfirm = () => {
+    onConfirm();
+    closeModal();
+  };
+
+  return (
+    <div className="fixed inset-0 z-100 flex items-center justify-center bg-overlay px-6">
+      <div className="flex w-full max-w-xl flex-col gap-8 rounded-2xl bg-white p-10 text-coolgray-90 shadow-xl">
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-2">
+            <h2 className="text-heading-4">{title}</h2>
+            <p className="text-heading-6 text-coolgray-90">{action}</p>
+          </div>
+          {description && <p className="text-body-m text-coolgray-60">{description}</p>}
+        </div>
+
+        {details && <div className="rounded-xl border border-primary-60/30 bg-primary-30 p-5">{details}</div>}
+
+        <div className="flex justify-end gap-3">
+          <Button variant="outlined" className="w-32" onClick={closeModal}>
+            {cancelText}
+          </Button>
+          <Button variant={confirmVariant} className="w-32" onClick={handleConfirm}>
+            {confirmText}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/adminFilterPill.tsx
+++ b/src/components/admin/adminFilterPill.tsx
@@ -1,0 +1,21 @@
+interface IAdminFilterPillProps {
+  active: boolean;
+  label: string;
+  onClick: () => void;
+}
+
+export default function AdminFilterPill({ active, label, onClick }: IAdminFilterPillProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded-full border px-4 py-2 text-button-s transition-colors ${
+        active
+          ? 'border-primary-60 bg-primary-30 text-primary-90'
+          : 'border-coolgray-20 bg-white text-coolgray-60 hover:border-primary-60 hover:text-primary-60'
+      }`}
+    >
+      {label}
+    </button>
+  );
+}

--- a/src/components/admin/adminModeToggle.tsx
+++ b/src/components/admin/adminModeToggle.tsx
@@ -1,0 +1,27 @@
+import { useLocation, useNavigate } from 'react-router-dom';
+
+import Toggle from '@/components/common/toggle';
+import useCurrentRole from '@/hooks/auth/useCurrentRole';
+import { isAdminRole } from '@/utils/authRole';
+
+// ADMIN/SUPER_ADMIN 사용자에게만 보이는 학생/관리자 화면 전환 토글.
+export default function AdminModeToggle() {
+  const role = useCurrentRole();
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const isAdminPage = pathname.startsWith('/admin');
+
+  if (!isAdminRole(role)) return null;
+
+  const handleChange = (checked: boolean) => {
+    navigate(checked ? '/admin/course-classifications' : '/');
+  };
+
+  return (
+    <div className="flex items-center gap-2 rounded-full border border-primary-60/30 bg-primary-30 px-4 py-2">
+      <span className={`text-body-xs ${isAdminPage ? 'text-coolgray-60' : 'text-primary-90'}`}>학생</span>
+      <Toggle checked={isAdminPage} onChange={handleChange} />
+      <span className={`text-body-xs ${isAdminPage ? 'text-primary-90' : 'text-coolgray-60'}`}>관리자</span>
+    </div>
+  );
+}

--- a/src/components/admin/courseClassificationFilters.tsx
+++ b/src/components/admin/courseClassificationFilters.tsx
@@ -1,0 +1,87 @@
+import MultiSelectDropdown from '@/components/admin/multiSelectDropdown';
+import type { TAdminAreaType } from '@/types/admin/TGetAdminAreaTypes';
+import { COURSE_LABEL, COURSE_TYPES, type TCourseType } from '@/types/course';
+
+interface ICourseClassificationFiltersProps {
+  areaTypes: TAdminAreaType[];
+  selectedAreaTypeIds: number[];
+  selectedCourseTypes: TCourseType[];
+  yearInput: string;
+  // 다중 선택이므로 선택/해제할 값 하나를 토글하도록 알린다.
+  onAreaTypeToggle: (areaTypeId: number) => void;
+  onCourseTypeToggle: (courseType: TCourseType) => void;
+  onYearInputChange: (value: string) => void;
+  onApply: () => void;
+  onReset: () => void;
+}
+
+export default function CourseClassificationFilters({
+  areaTypes,
+  selectedAreaTypeIds,
+  selectedCourseTypes,
+  yearInput,
+  onAreaTypeToggle,
+  onCourseTypeToggle,
+  onYearInputChange,
+  onApply,
+  onReset,
+}: ICourseClassificationFiltersProps) {
+  // 이수구분/이수 영역 다중 선택 드롭다운에 넘길 옵션 목록 (값 + 표시명)
+  const courseTypeOptions = COURSE_TYPES.map((courseType) => ({ value: courseType, label: COURSE_LABEL[courseType] }));
+  const areaTypeOptions = areaTypes.map((areaType) => ({ value: areaType.id, label: areaType.areaName }));
+
+  return (
+    <section className="flex h-full flex-col gap-5 rounded-2xl border border-coolgray-10 bg-white p-8 shadow-sm">
+      <div>
+        <h2 className="text-heading-5 text-coolgray-90">과목 분류 필터</h2>
+        <p className="mt-1 text-body-s text-coolgray-60">
+          조회 조건을 선택한 뒤 필터를 적용합니다. (다중 선택 가능, 미선택 시 전체)
+        </p>
+      </div>
+
+      {/* 이수구분 · 이수 영역: 다중 선택 드롭다운을 한 줄에 나란히 배치해 여백을 줄인다. */}
+      <div className="grid grid-cols-2 gap-3">
+        <div className="flex flex-col gap-1.5">
+          <span className="text-body-s font-semibold text-coolgray-90">이수구분</span>
+          <MultiSelectDropdown
+            options={courseTypeOptions}
+            selectedValues={selectedCourseTypes}
+            onToggle={onCourseTypeToggle}
+          />
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <span className="text-body-s font-semibold text-coolgray-90">이수 영역</span>
+          <MultiSelectDropdown
+            options={areaTypeOptions}
+            selectedValues={selectedAreaTypeIds}
+            onToggle={onAreaTypeToggle}
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <span className="text-body-s font-semibold text-coolgray-90">입학년도</span>
+        <input
+          value={yearInput}
+          onChange={(event) => onYearInputChange(event.target.value)}
+          placeholder="예: 2023,2024"
+          className="rounded-lg border border-coolgray-20 bg-white px-3 py-2 text-body-s text-coolgray-90 outline-none placeholder:text-coolgray-60 focus:border-primary-60"
+        />
+      </div>
+
+      <div className="mt-auto flex justify-end gap-2">
+        <button type="button" className="rounded-full px-5 py-2 text-button-s text-coolgray-60" onClick={onReset}>
+          초기화
+        </button>
+        <button
+          type="button"
+          className="rounded-full bg-primary-60 px-5 py-2 text-button-s text-white hover:opacity-90"
+          onClick={onApply}
+        >
+          필터 적용
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/components/admin/courseClassificationForm.tsx
+++ b/src/components/admin/courseClassificationForm.tsx
@@ -1,0 +1,114 @@
+import CourseClassificationFormRow from '@/components/admin/courseClassificationFormRow';
+import Button from '@/components/common/button';
+import type { TAdminAreaType } from '@/types/admin/TGetAdminAreaTypes';
+import type { TCourseType } from '@/types/course';
+
+// 과목 분류 폼 한 행의 입력 상태(UI 전용). 모든 값은 입력 편의를 위해 문자열로 다룬다.
+export type TCourseClassificationFormState = {
+  id: number | null;
+  courseCode: string;
+  tag: string;
+  studentYearStart: string;
+  studentYearEnd: string;
+  courseType: TCourseType | '';
+  areaTypeId: string;
+  subCategory: string;
+  subjectDomain: string;
+};
+
+// 폼에서 관리하는 개별 행. clientId로 행을 구분한다.
+export type TCourseClassificationDraft = TCourseClassificationFormState & {
+  clientId: string;
+};
+
+interface ICourseClassificationFormProps {
+  areaTypes: TAdminAreaType[];
+  drafts: TCourseClassificationDraft[];
+  isSaving: boolean;
+  onChange: (clientId: string, field: keyof TCourseClassificationFormState, value: string) => void;
+  onAddNew: () => void;
+  onRemove: (clientId: string) => void;
+  onSubmit: () => void;
+}
+
+const HEADER_CELL_CLASS = 'px-3 py-3 text-left text-body-s font-semibold text-primary-90';
+
+export default function CourseClassificationForm({
+  areaTypes,
+  drafts,
+  isSaving,
+  onChange,
+  onAddNew,
+  onRemove,
+  onSubmit,
+}: ICourseClassificationFormProps) {
+  return (
+    <section className="flex flex-col gap-5 rounded-2xl border border-coolgray-10 bg-white p-8 shadow-sm">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-heading-5 text-coolgray-90">과목 분류 수정</h2>
+          <p className="mt-1 text-body-s text-coolgray-60">
+            목록에서 과목을 선택하거나 신규 버튼으로 빈 행을 추가해 한 번에 저장합니다.
+          </p>
+        </div>
+        <div className="flex gap-4">
+          <Button
+            variant={isSaving ? 'disabled' : 'outlined'}
+            disabled={isSaving}
+            onClick={onAddNew}
+            className="w-20 py-3.5"
+          >
+            신규
+          </Button>
+          <Button
+            variant={drafts.length > 0 && !isSaving ? 'primary' : 'disabled'}
+            disabled={drafts.length === 0 || isSaving}
+            onClick={onSubmit}
+            className="w-28 py-3.5"
+          >
+            수정하기
+          </Button>
+        </div>
+      </div>
+
+      <div className="overflow-x-auto rounded-xl border border-coolgray-10">
+        <table className="min-w-[1180px] w-full border-collapse">
+          <thead className="bg-primary-30">
+            <tr>
+              <th className="w-18 px-3 py-3 text-left text-body-s font-semibold text-primary-90">구분</th>
+              <th className="w-32 px-3 py-3 text-left text-body-s font-semibold text-primary-90">과목코드</th>
+              <th className="w-40 px-3 py-3 text-left text-body-s font-semibold text-primary-90">표시명</th>
+              <th className="w-32 px-3 py-3 text-left text-body-s font-semibold text-primary-90">시작년도</th>
+              <th className="w-32 px-3 py-3 text-left text-body-s font-semibold text-primary-90">종료년도</th>
+              <th className="w-40 px-3 py-3 text-left text-body-s font-semibold text-primary-90">이수구분</th>
+              <th className="w-48 px-3 py-3 text-left text-body-s font-semibold text-primary-90">이수 영역</th>
+              <th className={HEADER_CELL_CLASS}>세부분류</th>
+              <th className={HEADER_CELL_CLASS}>학문영역</th>
+              <th className="w-20 px-3 py-3" />
+            </tr>
+          </thead>
+          <tbody>
+            {drafts.length === 0 ? (
+              <tr>
+                <td colSpan={10} className="px-4 py-10 text-center text-body-m text-coolgray-60">
+                  수정할 과목을 선택하거나 신규 행을 추가해주세요.
+                </td>
+              </tr>
+            ) : (
+              drafts.map((draft) => (
+                <CourseClassificationFormRow
+                  key={draft.clientId}
+                  draft={draft}
+                  areaTypes={areaTypes}
+                  isSaving={isSaving}
+                  onChange={onChange}
+                  onRemove={onRemove}
+                />
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/src/components/admin/courseClassificationFormRow.tsx
+++ b/src/components/admin/courseClassificationFormRow.tsx
@@ -1,0 +1,150 @@
+import type {
+  TCourseClassificationDraft,
+  TCourseClassificationFormState,
+} from '@/components/admin/courseClassificationForm';
+import type { TAdminAreaType } from '@/types/admin/TGetAdminAreaTypes';
+import { COURSE_LABEL, COURSE_TYPES } from '@/types/course';
+
+const INPUT_CLASS =
+  'w-full rounded-lg border border-coolgray-20 bg-white px-3 py-2 text-body-s text-coolgray-90 outline-none placeholder:text-coolgray-60 focus:border-primary-60 disabled:bg-coolgray-10 disabled:text-coolgray-60';
+
+const BODY_CELL_CLASS = 'px-3 py-3 align-top';
+
+// 네이티브 화살표를 숨긴 select(appearance-none) 위에 커스텀 꺽쇠를 칸 안쪽으로 들여 그린다.
+function SelectChevron() {
+  return (
+    <svg
+      className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-coolgray-60"
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <path d="M5 8l5 5 5-5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+interface ICourseClassificationFormRowProps {
+  draft: TCourseClassificationDraft;
+  areaTypes: TAdminAreaType[];
+  isSaving: boolean;
+  onChange: (clientId: string, field: keyof TCourseClassificationFormState, value: string) => void;
+  onRemove: (clientId: string) => void;
+}
+
+// 과목 분류 수정 테이블의 한 행. 신규/수정 구분 배지, 입력 필드, 삭제 버튼을 렌더링한다.
+export default function CourseClassificationFormRow({
+  draft,
+  areaTypes,
+  isSaving,
+  onChange,
+  onRemove,
+}: ICourseClassificationFormRowProps) {
+  return (
+    <tr className="border-t border-coolgray-10">
+      <td className="px-3 py-3">
+        {/* 신규로 추가한 행과 기존 데이터를 수정하는 행을 배지로 구분한다. */}
+        <span className="rounded-full bg-primary-30 px-3 py-1 text-body-xs font-semibold text-primary-90">
+          {draft.id === null ? '신규' : '수정'}
+        </span>
+      </td>
+      <td className={BODY_CELL_CLASS}>
+        <input
+          value={draft.courseCode}
+          disabled={isSaving}
+          onChange={(event) => onChange(draft.clientId, 'courseCode', event.target.value)}
+          className={INPUT_CLASS}
+        />
+      </td>
+      <td className={BODY_CELL_CLASS}>
+        <input
+          value={draft.tag}
+          disabled={isSaving}
+          onChange={(event) => onChange(draft.clientId, 'tag', event.target.value)}
+          className={INPUT_CLASS}
+        />
+      </td>
+      <td className={BODY_CELL_CLASS}>
+        <input
+          value={draft.studentYearStart}
+          disabled={isSaving}
+          inputMode="numeric"
+          onChange={(event) => onChange(draft.clientId, 'studentYearStart', event.target.value)}
+          className={INPUT_CLASS}
+        />
+      </td>
+      <td className={BODY_CELL_CLASS}>
+        <input
+          value={draft.studentYearEnd}
+          disabled={isSaving}
+          inputMode="numeric"
+          onChange={(event) => onChange(draft.clientId, 'studentYearEnd', event.target.value)}
+          className={INPUT_CLASS}
+        />
+      </td>
+      <td className={BODY_CELL_CLASS}>
+        <div className="relative">
+          <select
+            value={draft.courseType}
+            disabled={isSaving}
+            onChange={(event) => onChange(draft.clientId, 'courseType', event.target.value)}
+            className={`${INPUT_CLASS} appearance-none pr-8`}
+          >
+            <option value="">선택</option>
+            {COURSE_TYPES.map((courseType) => (
+              <option key={courseType} value={courseType}>
+                {COURSE_LABEL[courseType]}
+              </option>
+            ))}
+          </select>
+          <SelectChevron />
+        </div>
+      </td>
+      <td className={BODY_CELL_CLASS}>
+        <div className="relative">
+          <select
+            value={draft.areaTypeId}
+            disabled={isSaving}
+            onChange={(event) => onChange(draft.clientId, 'areaTypeId', event.target.value)}
+            className={`${INPUT_CLASS} appearance-none pr-8`}
+          >
+            <option value="">없음</option>
+            {areaTypes.map((areaType) => (
+              <option key={areaType.id} value={areaType.id}>
+                {areaType.areaName}
+              </option>
+            ))}
+          </select>
+          <SelectChevron />
+        </div>
+      </td>
+      <td className={BODY_CELL_CLASS}>
+        <input
+          value={draft.subCategory}
+          disabled={isSaving}
+          onChange={(event) => onChange(draft.clientId, 'subCategory', event.target.value)}
+          className={INPUT_CLASS}
+        />
+      </td>
+      <td className={BODY_CELL_CLASS}>
+        <input
+          value={draft.subjectDomain}
+          disabled={isSaving}
+          onChange={(event) => onChange(draft.clientId, 'subjectDomain', event.target.value)}
+          className={INPUT_CLASS}
+        />
+      </td>
+      <td className="px-3 py-3 text-center">
+        <button
+          type="button"
+          disabled={isSaving}
+          onClick={() => onRemove(draft.clientId)}
+          className="whitespace-nowrap rounded-full px-2 py-1 text-body-s text-coolgray-60 hover:text-primary-60 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          삭제
+        </button>
+      </td>
+    </tr>
+  );
+}

--- a/src/components/admin/courseClassificationTable.tsx
+++ b/src/components/admin/courseClassificationTable.tsx
@@ -21,7 +21,9 @@ export default function CourseClassificationTable({
   onToggleAll,
   onToggleRow,
 }: ICourseClassificationTableProps) {
-  const allChecked = courses.length > 0 && selectedIds.size === courses.length;
+  // 현재 목록(courses)의 모든 과목이 선택되었는지 검사한다.
+  // selectedIds.size 비교 대신 courses.every를 사용해, selectedIds에 현재 목록에 없는 ID가 섞여 있어도 정확히 판정한다.
+  const allChecked = courses.length > 0 && courses.every((course) => selectedIds.has(course.id));
 
   return (
     <section className="flex flex-col gap-5 rounded-2xl border border-coolgray-10 bg-white p-8 shadow-sm">

--- a/src/components/admin/courseClassificationTable.tsx
+++ b/src/components/admin/courseClassificationTable.tsx
@@ -1,0 +1,130 @@
+import type { TAdminCourseClassification } from '@/types/admin/TGetCourseClassifications';
+import { COURSE_LABEL } from '@/types/course';
+
+interface ICourseClassificationTableProps {
+  courses: TAdminCourseClassification[];
+  selectedIds: Set<number>;
+  isLoading: boolean;
+  isError: boolean;
+  onToggleAll: (checked: boolean) => void;
+  onToggleRow: (courseId: number, checked: boolean) => void;
+}
+
+const HEADER_CELL_CLASS = 'px-4 py-3 text-left text-body-s font-semibold text-primary-90';
+const BODY_CELL_CLASS = 'px-4 py-4 text-body-s text-coolgray-90';
+
+export default function CourseClassificationTable({
+  courses,
+  selectedIds,
+  isLoading,
+  isError,
+  onToggleAll,
+  onToggleRow,
+}: ICourseClassificationTableProps) {
+  const allChecked = courses.length > 0 && selectedIds.size === courses.length;
+
+  return (
+    <section className="flex flex-col gap-5 rounded-2xl border border-coolgray-10 bg-white p-8 shadow-sm">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-heading-5 text-coolgray-90">과목 분류 목록</h2>
+          <p className="mt-1 text-body-s text-coolgray-60">조회 결과 {courses.length.toLocaleString()}건</p>
+        </div>
+        <span className="rounded-full bg-primary-30 px-4 py-2 text-button-s text-primary-90">
+          선택 {selectedIds.size.toLocaleString()}건
+        </span>
+      </div>
+
+      <div className="max-h-[590px] overflow-auto rounded-xl border border-coolgray-10">
+        <table className="min-w-[980px] w-full table-fixed border-collapse bg-white">
+          <colgroup>
+            <col className="w-12" />
+            <col className="w-[13%]" />
+            {/* 표시명 너비를 넓히고, 세부분류·학문영역 너비를 줄였다. */}
+            <col className="w-[22%]" />
+            <col className="w-[13%]" />
+            <col className="w-[13%]" />
+            <col className="w-[17%]" />
+            <col className="w-[11%]" />
+            <col className="w-[11%]" />
+          </colgroup>
+          <thead className="sticky top-0 z-10 bg-primary-30">
+            <tr>
+              <th className="px-4 py-3 text-left">
+                <input
+                  type="checkbox"
+                  checked={allChecked}
+                  disabled={courses.length === 0}
+                  onChange={(event) => onToggleAll(event.target.checked)}
+                  className="h-4 w-4 accent-primary-60"
+                  aria-label="전체 과목 선택"
+                />
+              </th>
+              <th className={HEADER_CELL_CLASS}>과목코드</th>
+              <th className={HEADER_CELL_CLASS}>표시명</th>
+              <th className={HEADER_CELL_CLASS}>적용년도</th>
+              <th className={HEADER_CELL_CLASS}>이수구분</th>
+              <th className={HEADER_CELL_CLASS}>이수 영역</th>
+              <th className={HEADER_CELL_CLASS}>세부분류</th>
+              <th className={HEADER_CELL_CLASS}>학문영역</th>
+            </tr>
+          </thead>
+          <tbody>
+            {isLoading && (
+              <tr>
+                <td colSpan={8} className="px-4 py-16 text-center text-body-m text-coolgray-60">
+                  과목 분류를 불러오는 중입니다.
+                </td>
+              </tr>
+            )}
+            {isError && !isLoading && (
+              <tr>
+                <td colSpan={8} className="px-4 py-16 text-center text-body-m text-alert">
+                  과목 분류 정보를 불러오지 못했어요.
+                </td>
+              </tr>
+            )}
+            {!isLoading && !isError && courses.length === 0 && (
+              <tr>
+                <td colSpan={8} className="px-4 py-16 text-center text-body-m text-coolgray-60">
+                  조건에 맞는 과목 분류가 없습니다.
+                </td>
+              </tr>
+            )}
+            {!isLoading &&
+              !isError &&
+              courses.map((course) => (
+                <tr
+                  key={course.id}
+                  className={`border-t border-coolgray-10 transition-colors ${
+                    selectedIds.has(course.id) ? 'bg-primary-30/70' : 'hover:bg-coolgray-10/50'
+                  }`}
+                >
+                  <td className="px-4 py-4">
+                    <input
+                      type="checkbox"
+                      checked={selectedIds.has(course.id)}
+                      onChange={(event) => onToggleRow(course.id, event.target.checked)}
+                      className="h-4 w-4 accent-primary-60"
+                      aria-label={`${course.courseCode} 선택`}
+                    />
+                  </td>
+                  <td className={`${BODY_CELL_CLASS} font-semibold`}>{course.courseCode}</td>
+                  <td className={BODY_CELL_CLASS}>
+                    <span className="block truncate">{course.tag ?? '-'}</span>
+                  </td>
+                  <td className={BODY_CELL_CLASS}>
+                    {course.studentYearStart} - {course.studentYearEnd}
+                  </td>
+                  <td className={BODY_CELL_CLASS}>{COURSE_LABEL[course.courseType]}</td>
+                  <td className={BODY_CELL_CLASS}>{course.areaName ?? '-'}</td>
+                  <td className={BODY_CELL_CLASS}>{course.subCategory ?? '-'}</td>
+                  <td className={BODY_CELL_CLASS}>{course.subjectDomain ?? '-'}</td>
+                </tr>
+              ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/src/components/admin/multiSelectDropdown.tsx
+++ b/src/components/admin/multiSelectDropdown.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useRef, useState } from 'react';
+
+// 다중 선택 드롭다운에서 사용할 옵션 한 개. value는 실제 값, label은 표시 문자열이다.
+interface IMultiSelectOption<T extends string | number> {
+  value: T;
+  label: string;
+}
+
+interface IMultiSelectDropdownProps<T extends string | number> {
+  // 옵션 목록 (값 + 표시명)
+  options: IMultiSelectOption<T>[];
+  // 현재 선택된 값들
+  selectedValues: T[];
+  // 항목을 누를 때마다 해당 값의 선택/해제를 토글하도록 알린다.
+  onToggle: (value: T) => void;
+  // 아무것도 선택하지 않았을 때 트리거에 보여줄 문구 (기본 '전체')
+  allLabel?: string;
+  disabled?: boolean;
+}
+
+// 필터용 커스텀 다중 선택 드롭다운.
+// - 트리거를 클릭하면 펼쳐지고, 트리거를 다시 누르거나 바깥을 클릭해야 닫힌다.
+// - 항목을 선택해도 닫히지 않으며, 선택된 항목은 primary-30 음영 + 체크 표시로 강조한다.
+// - 아무것도 선택하지 않은 상태는 '전체'를 의미한다.
+export default function MultiSelectDropdown<T extends string | number>({
+  options,
+  selectedValues,
+  onToggle,
+  allLabel = '전체',
+  disabled = false,
+}: IMultiSelectDropdownProps<T>) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // 메뉴가 열려 있을 때 바깥 영역을 클릭하면 닫는다. (항목 선택으로는 닫히지 않음)
+  useEffect(() => {
+    if (!open) return;
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [open]);
+
+  // 선택된 항목들의 표시명을 모아 트리거 요약 문구를 만든다. 선택이 없으면 '전체'.
+  const selectedLabels = options
+    .filter((option) => selectedValues.includes(option.value))
+    .map((option) => option.label);
+  const hasSelection = selectedLabels.length > 0;
+  const summary = hasSelection ? selectedLabels.join(', ') : allLabel;
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => setOpen((prev) => !prev)}
+        className="flex w-full items-center justify-between gap-2 rounded-lg border border-coolgray-20 bg-white py-2 pl-3 pr-3 text-body-s outline-none focus:border-primary-60 disabled:cursor-not-allowed disabled:bg-coolgray-10"
+      >
+        <span className={`truncate ${hasSelection ? 'text-coolgray-90' : 'text-coolgray-60'}`}>{summary}</span>
+        {/* 커스텀 꺽쇠. 칸 안쪽(pr-3)에 들여 두고, 열리면 위로 회전한다. */}
+        <svg
+          className={`h-4 w-4 shrink-0 text-coolgray-60 transition-transform ${open ? 'rotate-180' : ''}`}
+          viewBox="0 0 20 20"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <path d="M5 8l5 5 5-5" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </button>
+
+      {open && (
+        <ul className="absolute z-20 mt-1 max-h-60 w-full overflow-auto rounded-lg border border-coolgray-20 bg-white py-1 shadow-lg">
+          {options.length === 0 ? (
+            <li className="px-3 py-2 text-body-s text-coolgray-60">옵션이 없습니다.</li>
+          ) : (
+            options.map((option) => {
+              const checked = selectedValues.includes(option.value);
+              return (
+                <li key={String(option.value)}>
+                  <button
+                    type="button"
+                    onClick={() => onToggle(option.value)}
+                    className={`flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-body-s ${
+                      checked ? 'bg-primary-30 text-primary-90' : 'text-coolgray-90 hover:bg-coolgray-10/60'
+                    }`}
+                  >
+                    <span className="truncate">{option.label}</span>
+                    {/* 선택된 항목에는 체크 표시를 보여준다. */}
+                    {checked && (
+                      <svg
+                        className="h-4 w-4 shrink-0 text-primary-90"
+                        viewBox="0 0 20 20"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2.5"
+                      >
+                        <path d="M4 10l4 4 8-8" strokeLinecap="round" strokeLinejoin="round" />
+                      </svg>
+                    )}
+                  </button>
+                </li>
+              );
+            })
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/common/header.tsx
+++ b/src/components/common/header.tsx
@@ -1,9 +1,10 @@
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { toast } from 'sonner';
 
 import Headset from '@/assets/headset.svg?react';
 import Logo from '@/assets/logo.svg?react';
 import UserThumb from '@/assets/userThumb.svg?react';
+import AdminModeToggle from '@/components/admin/adminModeToggle';
 import { KAKAO_CHAT_URL, READY_MESSAGE } from '@/constants/links';
 
 // 졸업 판정만 실제 페이지로 연결하고, 커리큘럼은 아직 미개발이라 토스트로 안내한다.
@@ -12,7 +13,42 @@ const NAV_ITEMS = [
   { name: '커리큘럼', type: 'toast' },
 ] as const;
 
+const ADMIN_NAV_ITEMS = [
+  { name: '과목 관리', path: '/admin/course-classifications' },
+  { name: '졸업 요건 관리', path: '/admin/graduation-requirements' },
+] as const;
+
 export default function Header() {
+  const { pathname } = useLocation();
+  const isAdminPage = pathname.startsWith('/admin');
+  const navBaseClass = 'rounded-full px-5 py-3 hover:cursor-pointer hover:text-primary-60';
+
+  if (isAdminPage) {
+    return (
+      <header className="sticky top-0 z-50 w-full border-b border-coolgray-10 bg-white text-coolgray-90">
+        <div className="flex items-center justify-between px-16 py-2">
+          <div className="flex items-center gap-12">
+            <Logo className="w-40 h-auto" />
+            <div className="flex items-center gap-2 text-button-m">
+              {ADMIN_NAV_ITEMS.map((item) => (
+                <Link
+                  key={item.name}
+                  to={item.path}
+                  className={`${navBaseClass} ${
+                    pathname === item.path ? 'bg-primary-30 text-primary-90' : 'text-coolgray-90'
+                  }`}
+                >
+                  {item.name}
+                </Link>
+              ))}
+            </div>
+          </div>
+          <AdminModeToggle />
+        </div>
+      </header>
+    );
+  }
+
   return (
     <header className="sticky top-0 z-50 w-full bg-white text-coolgray-90">
       <div className="flex items-center justify-between py-2 px-16">
@@ -23,7 +59,13 @@ export default function Header() {
           <div className="flex items-center gap-2 text-button-m">
             {NAV_ITEMS.map((item) =>
               item.type === 'link' ? (
-                <Link key={item.name} to={item.path} className="px-2 py-3 hover:text-primary-60 hover:cursor-pointer">
+                <Link
+                  key={item.name}
+                  to={item.path}
+                  className={`${navBaseClass} ${
+                    pathname === item.path ? 'bg-primary-30 text-primary-90' : 'text-coolgray-90'
+                  }`}
+                >
                   {item.name}
                 </Link>
               ) : (
@@ -32,7 +74,7 @@ export default function Header() {
                   key={item.name}
                   type="button"
                   onClick={() => toast(READY_MESSAGE)}
-                  className="px-2 py-3 hover:text-primary-60 hover:cursor-pointer"
+                  className={`${navBaseClass} text-coolgray-90`}
                 >
                   {item.name}
                 </button>
@@ -55,6 +97,7 @@ export default function Header() {
             <UserThumb className="w-8 h-8" />
             <span>마이페이지</span>
           </Link>
+          <AdminModeToggle />
         </div>
       </div>
     </header>

--- a/src/components/common/header.tsx
+++ b/src/components/common/header.tsx
@@ -28,7 +28,10 @@ export default function Header() {
       <header className="sticky top-0 z-50 w-full border-b border-coolgray-10 bg-white text-coolgray-90">
         <div className="flex items-center justify-between px-16 py-2">
           <div className="flex items-center gap-12">
-            <Logo className="w-40 h-auto" />
+            {/* 일반 헤더와 동일하게 로고 클릭 시 관리자 메인(/admin)으로 이동하도록 Link로 감싼다. */}
+            <Link to="/admin">
+              <Logo className="hover:cursor-pointer w-40 h-auto" />
+            </Link>
             <div className="flex items-center gap-2 text-button-m">
               {ADMIN_NAV_ITEMS.map((item) => (
                 <Link

--- a/src/components/common/modalProvider.tsx
+++ b/src/components/common/modalProvider.tsx
@@ -1,3 +1,4 @@
+import AdminConfirmModal from '@/components/admin/adminConfirmModal';
 import Modal from '@/components/common/modal';
 import OnBoardingModal from '@/components/onBoardingModal';
 import { useModalStore } from '@/stores/modalStore';
@@ -7,5 +8,6 @@ export default function ModalProvider() {
 
   if (type === 'alert') return <Modal />;
   if (type === 'onboarding') return <OnBoardingModal />;
+  if (type === 'confirm') return <AdminConfirmModal />;
   return null;
 }

--- a/src/constants/querykeys/queryKeys.ts
+++ b/src/constants/querykeys/queryKeys.ts
@@ -5,4 +5,9 @@ export const QUERY_KEYS = {
   REPORTS_ROOT: ['reports'] as const,
   GET_REPORT_SUMMARY: ['reports', 'summary'] as const,
   GET_REPORT_BY_COURSE_TYPE: (courseType: string) => ['reports', { courseType }] as const,
+  ADMIN_ROOT: ['admin'] as const,
+  GET_ADMIN_AREA_TYPES: ['admin', 'area-types'] as const,
+  // 관리자 과목 분류 조회를 필터별로 캐시하고, 저장 후에는 이 접두사로 한 번에 무효화한다.
+  ADMIN_COURSE_CLASSIFICATIONS_ROOT: ['admin', 'course-classifications'] as const,
+  GET_ADMIN_COURSE_CLASSIFICATIONS: (filters: object) => ['admin', 'course-classifications', filters] as const,
 } as const;

--- a/src/hooks/admin/useAdminAreaTypes.ts
+++ b/src/hooks/admin/useAdminAreaTypes.ts
@@ -1,0 +1,8 @@
+import { getAdminAreaTypes } from '@/apis/admin/courseClassification';
+import { QUERY_KEYS } from '@/constants/querykeys/queryKeys';
+import { useCoreQuery } from '@/hooks/customQuery';
+
+// 과목 분류 필터와 저장 폼에서 공통으로 사용하는 이수 영역 목록.
+export default function useAdminAreaTypes() {
+  return useCoreQuery(QUERY_KEYS.GET_ADMIN_AREA_TYPES, () => getAdminAreaTypes());
+}

--- a/src/hooks/admin/useAdminCourseClassifications.ts
+++ b/src/hooks/admin/useAdminCourseClassifications.ts
@@ -1,0 +1,11 @@
+import { getAdminCourseClassifications } from '@/apis/admin/courseClassification';
+import { QUERY_KEYS } from '@/constants/querykeys/queryKeys';
+import { useCoreQuery } from '@/hooks/customQuery';
+import type { TCourseClassificationFilters } from '@/types/admin/TGetCourseClassifications';
+
+// 관리자 과목 분류 목록 조회. 필터 객체를 query key에 포함해 필터별 캐시를 분리한다.
+export default function useAdminCourseClassifications(filters: TCourseClassificationFilters) {
+  return useCoreQuery(QUERY_KEYS.GET_ADMIN_COURSE_CLASSIFICATIONS(filters), () =>
+    getAdminCourseClassifications(filters),
+  );
+}

--- a/src/hooks/admin/useUpsertCourseClassifications.ts
+++ b/src/hooks/admin/useUpsertCourseClassifications.ts
@@ -1,0 +1,17 @@
+import { useQueryClient } from '@tanstack/react-query';
+
+import { putAdminCourseClassifications } from '@/apis/admin/courseClassification';
+import { QUERY_KEYS } from '@/constants/querykeys/queryKeys';
+import { useCoreMutation } from '@/hooks/customQuery';
+import type { TCourseClassificationUpsertRequest } from '@/types/admin/TPutCourseClassifications';
+
+// 과목 분류 등록/수정 통합 저장 훅. 저장 성공 후 과목 분류 조회 캐시를 모두 무효화한다.
+export default function useUpsertCourseClassifications() {
+  const queryClient = useQueryClient();
+
+  return useCoreMutation<number[], TCourseClassificationUpsertRequest>((body) => putAdminCourseClassifications(body), {
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.ADMIN_COURSE_CLASSIFICATIONS_ROOT });
+    },
+  });
+}

--- a/src/hooks/auth/useCurrentRole.ts
+++ b/src/hooks/auth/useCurrentRole.ts
@@ -1,0 +1,8 @@
+import { useAuthStore } from '@/stores/authStore';
+import { getRoleFromAccessToken } from '@/utils/authRole';
+
+// accessToken은 메모리 zustand store에만 저장되므로, 헤더/라우트 게이트에서 role 클레임을 즉시 계산해 사용한다.
+export default function useCurrentRole() {
+  const accessToken = useAuthStore((state) => state.accessToken);
+  return getRoleFromAccessToken(accessToken);
+}

--- a/src/pages/admin/courseClassifications.tsx
+++ b/src/pages/admin/courseClassifications.tsx
@@ -1,0 +1,336 @@
+import { useRef, useState } from 'react';
+import { toast } from 'sonner';
+
+import CourseClassificationFilters from '@/components/admin/courseClassificationFilters';
+import type {
+  TCourseClassificationDraft,
+  TCourseClassificationFormState,
+} from '@/components/admin/courseClassificationForm';
+import CourseClassificationForm from '@/components/admin/courseClassificationForm';
+import CourseClassificationTable from '@/components/admin/courseClassificationTable';
+import useAdminAreaTypes from '@/hooks/admin/useAdminAreaTypes';
+import useAdminCourseClassifications from '@/hooks/admin/useAdminCourseClassifications';
+import useUpsertCourseClassifications from '@/hooks/admin/useUpsertCourseClassifications';
+import { useModalStore } from '@/stores/modalStore';
+import type { TAdminCourseClassification, TCourseClassificationFilters } from '@/types/admin/TGetCourseClassifications';
+import type { TCourseClassificationUpsertItem } from '@/types/admin/TPutCourseClassifications';
+import { COURSE_LABEL, type TCourseType } from '@/types/course';
+
+const EMPTY_FORM: TCourseClassificationFormState = {
+  id: null,
+  courseCode: '',
+  tag: '',
+  studentYearStart: '',
+  studentYearEnd: '',
+  courseType: '',
+  areaTypeId: '',
+  subCategory: '',
+  subjectDomain: '',
+};
+
+const optionalText = (value: string) => {
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+};
+
+const parseYears = (value: string) => {
+  const parsed = value
+    .split(',')
+    .map((year) => Number(year.trim()))
+    .filter((year) => Number.isInteger(year) && year > 0);
+  return Array.from(new Set(parsed));
+};
+
+const toDraft = (course: TAdminCourseClassification): TCourseClassificationDraft => ({
+  clientId: `course-${course.id}`,
+  id: course.id,
+  courseCode: course.courseCode,
+  tag: course.tag ?? '',
+  studentYearStart: String(course.studentYearStart),
+  studentYearEnd: String(course.studentYearEnd),
+  courseType: course.courseType,
+  areaTypeId: course.areaTypeId === null ? '' : String(course.areaTypeId),
+  subCategory: course.subCategory ?? '',
+  subjectDomain: course.subjectDomain ?? '',
+});
+
+const toPositiveInteger = (value: string) => {
+  const parsed = Number(value.trim());
+  if (!Number.isInteger(parsed) || parsed <= 0) return null;
+  return parsed;
+};
+
+export default function AdminCourseClassifications() {
+  const newDraftIndex = useRef(0);
+  const openConfirm = useModalStore((state) => state.openConfirm);
+  const [selectedAreaTypeIds, setSelectedAreaTypeIds] = useState<number[]>([]);
+  const [selectedCourseTypes, setSelectedCourseTypes] = useState<TCourseType[]>([]);
+  const [yearInput, setYearInput] = useState('');
+  const [appliedFilters, setAppliedFilters] = useState<TCourseClassificationFilters>({});
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [drafts, setDrafts] = useState<TCourseClassificationDraft[]>([]);
+
+  const { data: areaTypes = [], isError: isAreaTypeError } = useAdminAreaTypes();
+  const {
+    data: courses = [],
+    isPending: isCourseLoading,
+    isError: isCourseError,
+    refetch: refetchCourseClassifications,
+  } = useAdminCourseClassifications(appliedFilters);
+  const { mutate: upsertCourseClassifications, isPending: isSaving } = useUpsertCourseClassifications();
+
+  const clearDrafts = () => {
+    setSelectedIds(new Set());
+    setDrafts([]);
+  };
+
+  const handleApplyFilters = () => {
+    const years = parseYears(yearInput);
+    clearDrafts();
+    setAppliedFilters({
+      ...(selectedAreaTypeIds.length > 0 ? { areaTypeIds: selectedAreaTypeIds } : {}),
+      ...(selectedCourseTypes.length > 0 ? { courseTypes: selectedCourseTypes } : {}),
+      ...(years.length > 0 ? { years } : {}),
+    });
+  };
+
+  const handleResetFilters = () => {
+    setSelectedAreaTypeIds([]);
+    setSelectedCourseTypes([]);
+    setYearInput('');
+    setAppliedFilters({});
+    clearDrafts();
+  };
+
+  const handleToggleAll = (checked: boolean) => {
+    const next = checked ? new Set(courses.map((course) => course.id)) : new Set<number>();
+    setSelectedIds(next);
+    setDrafts((prev) => {
+      const newDrafts = prev.filter((draft) => draft.id === null);
+      if (!checked) return newDrafts;
+
+      const existingDraftIds = new Set(prev.filter((draft) => draft.id !== null).map((draft) => draft.id));
+      const visibleDrafts = courses
+        .filter((course) => !existingDraftIds.has(course.id))
+        .map((course) => toDraft(course));
+      return [...prev, ...visibleDrafts];
+    });
+  };
+
+  const handleToggleRow = (courseId: number, checked: boolean) => {
+    const next = new Set(selectedIds);
+    if (checked) {
+      next.add(courseId);
+    } else {
+      next.delete(courseId);
+    }
+    setSelectedIds(next);
+    setDrafts((prev) => {
+      if (!checked) return prev.filter((draft) => draft.id !== courseId);
+
+      const selectedCourse = courses.find((course) => course.id === courseId);
+      if (!selectedCourse || prev.some((draft) => draft.id === courseId)) return prev;
+      return [...prev, toDraft(selectedCourse)];
+    });
+  };
+
+  const handleAddNewDraft = () => {
+    const clientId = `new-${newDraftIndex.current++}`;
+    setDrafts((prev) => [...prev, { ...EMPTY_FORM, clientId }]);
+  };
+
+  const handleRemoveDraft = (clientId: string) => {
+    const removedDraft = drafts.find((draft) => draft.clientId === clientId);
+    if (removedDraft?.id !== null && removedDraft?.id !== undefined) {
+      const nextSelectedIds = new Set(selectedIds);
+      nextSelectedIds.delete(removedDraft.id);
+      setSelectedIds(nextSelectedIds);
+    }
+    setDrafts((prev) => prev.filter((draft) => draft.clientId !== clientId));
+  };
+
+  const handleDraftChange = (clientId: string, field: keyof TCourseClassificationFormState, value: string) => {
+    setDrafts((prev) => prev.map((draft) => (draft.clientId === clientId ? { ...draft, [field]: value } : draft)));
+  };
+
+  const buildUpsertItem = (
+    draft: TCourseClassificationDraft,
+    index: number,
+  ): TCourseClassificationUpsertItem | null => {
+    const rowLabel = `${index + 1}번째 행`;
+    const courseCode = draft.courseCode.trim();
+    const studentYearStart = toPositiveInteger(draft.studentYearStart);
+    const studentYearEnd = toPositiveInteger(draft.studentYearEnd);
+
+    if (!courseCode) {
+      toast.error(`${rowLabel}의 과목코드를 입력해주세요.`);
+      return null;
+    }
+    if (!studentYearStart || !studentYearEnd) {
+      toast.error(`${rowLabel}의 적용년도는 양수 숫자로 입력해주세요.`);
+      return null;
+    }
+    if (studentYearStart > studentYearEnd) {
+      toast.error(`${rowLabel}의 적용 시작년도는 종료년도보다 클 수 없습니다.`);
+      return null;
+    }
+    if (!draft.courseType) {
+      toast.error(`${rowLabel}의 이수구분을 선택해주세요.`);
+      return null;
+    }
+
+    const areaTypeId = draft.areaTypeId ? toPositiveInteger(draft.areaTypeId) : null;
+    if (draft.areaTypeId && !areaTypeId) {
+      toast.error(`${rowLabel}의 이수 영역 값이 올바르지 않습니다.`);
+      return null;
+    }
+
+    return {
+      id: draft.id,
+      courseCode,
+      tag: optionalText(draft.tag),
+      studentYearStart,
+      studentYearEnd,
+      courseType: draft.courseType,
+      areaTypeId,
+      subCategory: optionalText(draft.subCategory),
+      subjectDomain: optionalText(draft.subjectDomain),
+    };
+  };
+
+  const handleSubmit = () => {
+    if (drafts.length === 0) {
+      toast.error('수정하거나 추가할 과목을 먼저 선택해주세요.');
+      return;
+    }
+
+    const items: TCourseClassificationUpsertItem[] = [];
+    for (const [index, draft] of drafts.entries()) {
+      const item = buildUpsertItem(draft, index);
+      if (!item) return;
+      items.push(item);
+    }
+
+    const createCount = items.filter((item) => item.id === null).length;
+    const updateCount = items.length - createCount;
+    const itemSummaries = items.map((item, index) => ({
+      clientId: drafts[index]?.clientId ?? item.courseCode,
+      item,
+    }));
+
+    openConfirm({
+      title: '과목 분류 수정',
+      action: `총 ${items.length}건 저장 (수정 ${updateCount}건, 신규 ${createCount}건)`,
+      description: '이 작업은 관리자 커리큘럼 데이터에 즉시 반영됩니다. 내용을 확인한 뒤 저장해주세요.',
+      confirmText: '수정하기',
+      cancelText: '취소하기',
+      details: (
+        <div className="flex max-h-52 flex-col gap-2 overflow-y-auto text-body-s">
+          {itemSummaries.map(({ clientId, item }) => {
+            const areaName = areaTypes.find((areaType) => areaType.id === item.areaTypeId)?.areaName ?? '없음';
+            return (
+              <div key={clientId} className="rounded-lg bg-white px-4 py-3">
+                <p className="font-semibold text-coolgray-90">
+                  {item.id === null ? '신규' : `ID ${item.id}`} · {item.courseCode}
+                </p>
+                <p className="mt-1 text-coolgray-60">
+                  {item.tag ?? '-'} · {item.studentYearStart}-{item.studentYearEnd} · {COURSE_LABEL[item.courseType]} ·{' '}
+                  {areaName}
+                </p>
+              </div>
+            );
+          })}
+        </div>
+      ),
+      onConfirm: () => {
+        upsertCourseClassifications(
+          { items },
+          {
+            onSuccess: () => {
+              toast.success('과목 분류를 수정했어요.');
+              clearDrafts();
+              refetchCourseClassifications();
+            },
+          },
+        );
+      },
+    });
+  };
+
+  return (
+    <main className="flex-1 bg-primary-30/30 px-10 py-12">
+      <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-8">
+        <div className="flex flex-col gap-2">
+          <h1 className="text-heading-3 text-coolgray-90">과목 관리</h1>
+          <p className="text-body-m text-coolgray-90">
+            과목 분류를 필터로 조회하고, 선택한 분류를 수정하거나 새 분류를 추가합니다.
+          </p>
+        </div>
+
+        {isAreaTypeError && (
+          <div className="rounded-2xl border border-alert/30 bg-white px-6 py-4 text-body-m text-alert">
+            이수 영역 목록을 불러오지 못했습니다. 영역 필터와 영역 선택 없이 작업해주세요.
+          </div>
+        )}
+
+        <div className="grid gap-8 lg:grid-cols-2">
+          <div className="min-h-72 rounded-2xl border border-primary-60/20 bg-white p-8 shadow-sm flex flex-col gap-2">
+            <p className="text-body-l text-primary-90">
+              과목 관리는 매년 바뀌는 학업이수 가이드의 과목에 대한 이수 영역 구분을 관리하는 데이터베이스입니다.
+            </p>
+            <p className="text-body-m text-coolgray-90">
+              PDF에서 표시되는 이수 영역이 수강년도에 의해 결정되는 것과 달리, 졸업 판정은 학생의 입학년도를 기준으로
+              진행되기 때문에 PDF 상 이수 영역을 다시 분류하는 작업이 필요합니다.
+            </p>
+            <p className="text-body-m text-coolgray-90">
+              따라서 해당 페이지에서는 학업 이수 가이드를 기준으로 공통교양이나 학문기초 과목의 이수 영역을 적용년도에
+              대해 분류하고 관리합니다.
+            </p>
+            <p className="text-body-m text-primary-90">
+              * 수정 시 DB에 즉시 반영되므로, 반드시 수정 내용을 검토한 뒤 저장해주세요.
+            </p>
+          </div>
+
+          <CourseClassificationFilters
+            areaTypes={areaTypes}
+            selectedAreaTypeIds={selectedAreaTypeIds}
+            selectedCourseTypes={selectedCourseTypes}
+            yearInput={yearInput}
+            onAreaTypeToggle={(areaTypeId) =>
+              setSelectedAreaTypeIds((prev) =>
+                prev.includes(areaTypeId) ? prev.filter((id) => id !== areaTypeId) : [...prev, areaTypeId],
+              )
+            }
+            onCourseTypeToggle={(courseType) =>
+              setSelectedCourseTypes((prev) =>
+                prev.includes(courseType) ? prev.filter((type) => type !== courseType) : [...prev, courseType],
+              )
+            }
+            onYearInputChange={setYearInput}
+            onApply={handleApplyFilters}
+            onReset={handleResetFilters}
+          />
+        </div>
+
+        <CourseClassificationForm
+          areaTypes={areaTypes}
+          drafts={drafts}
+          isSaving={isSaving}
+          onChange={handleDraftChange}
+          onAddNew={handleAddNewDraft}
+          onRemove={handleRemoveDraft}
+          onSubmit={handleSubmit}
+        />
+
+        <CourseClassificationTable
+          courses={courses}
+          selectedIds={selectedIds}
+          isLoading={isCourseLoading}
+          isError={isCourseError}
+          onToggleAll={handleToggleAll}
+          onToggleRow={handleToggleRow}
+        />
+      </div>
+    </main>
+  );
+}

--- a/src/pages/admin/graduationRequirements.tsx
+++ b/src/pages/admin/graduationRequirements.tsx
@@ -1,0 +1,18 @@
+export default function AdminGraduationRequirements() {
+  return (
+    <main className="flex-1 bg-coolgray-10/60 px-10 py-12">
+      <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-6">
+        <div className="flex flex-col gap-2">
+          <p className="text-body-m font-semibold text-primary-90">Admin Curriculum</p>
+          <h1 className="text-heading-3 text-coolgray-90">졸업 요건 관리</h1>
+          <p className="text-body-m text-coolgray-60">
+            졸업 규칙과 요건 세트 관리는 다음 PR에서 같은 관리자 레이아웃 위에 연결합니다.
+          </p>
+        </div>
+        <div className="rounded-2xl border border-primary-60/20 bg-white p-10 text-body-m text-coolgray-60 shadow-sm">
+          PR2에서 graduation_rule 조회/등록/수정, PR3에서 requirement_set 조합 UI를 추가할 예정입니다.
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/routes/adminRoute.tsx
+++ b/src/routes/adminRoute.tsx
@@ -1,0 +1,15 @@
+import { Navigate, Outlet } from 'react-router-dom';
+
+import useCurrentRole from '@/hooks/auth/useCurrentRole';
+import { isAdminRole } from '@/utils/authRole';
+
+// 관리자 라우트 게이트. 인증/온보딩은 ProtectedRoute가 먼저 처리하고, 여기서는 JWT role 클레임만 확인한다.
+export default function AdminRoute() {
+  const role = useCurrentRole();
+
+  if (!isAdminRole(role)) {
+    return <Navigate to="/" replace />;
+  }
+
+  return <Outlet />;
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,7 +1,9 @@
-import { createBrowserRouter } from 'react-router-dom';
+import { createBrowserRouter, Navigate } from 'react-router-dom';
 
 import Layout from '@/layouts';
 import AcademicRecords from '@/pages/academicRecords';
+import AdminCourseClassifications from '@/pages/admin/courseClassifications';
+import AdminGraduationRequirements from '@/pages/admin/graduationRequirements';
 import AuthCallback from '@/pages/authCallback';
 import Curriculum from '@/pages/curriculum';
 import Graduation from '@/pages/graduation';
@@ -12,6 +14,7 @@ import NotFound from '@/pages/notFound';
 import OnBoarding from '@/pages/onBoarding';
 import Profile from '@/pages/profile';
 import UploadPage from '@/pages/uploadPage';
+import AdminRoute from '@/routes/adminRoute';
 import ProtectedRoute from '@/routes/protectedRoute';
 import ReportGate from '@/routes/reportGate';
 
@@ -46,6 +49,19 @@ export const router = createBrowserRouter([
           },
           { path: 'onboarding', element: <OnBoarding /> },
           { path: 'upload', element: <UploadPage /> },
+          {
+            element: <AdminRoute />,
+            children: [
+              {
+                path: 'admin',
+                children: [
+                  { index: true, element: <Navigate to="course-classifications" replace /> },
+                  { path: 'course-classifications', element: <AdminCourseClassifications /> },
+                  { path: 'graduation-requirements', element: <AdminGraduationRequirements /> },
+                ],
+              },
+            ],
+          },
         ],
       },
       // 정의되지 않은 경로는 인증과 무관하게 NotFound를 보여준다. (public)

--- a/src/stores/modalStore.ts
+++ b/src/stores/modalStore.ts
@@ -1,7 +1,7 @@
 import type { ComponentType, ReactNode, SVGProps } from 'react';
 import { create } from 'zustand';
 
-type TModalType = 'alert' | 'onboarding';
+type TModalType = 'alert' | 'onboarding' | 'confirm';
 
 interface IAlertContent {
   icon: ComponentType<SVGProps<SVGSVGElement>>;
@@ -14,25 +14,40 @@ interface IAlertContent {
   onConfirm?: () => void;
 }
 
+interface IConfirmContent {
+  title: string;
+  action: string;
+  description?: string;
+  details?: ReactNode;
+  confirmText?: string;
+  cancelText?: string;
+  confirmVariant?: 'primary' | 'alert';
+  onConfirm: () => void;
+}
+
 interface IModalState {
   type: TModalType | null;
   alertContent: IAlertContent | null;
+  confirmContent: IConfirmContent | null;
 }
 
 interface IModalActions {
   openAlert: (content: IAlertContent) => void;
   openOnboarding: () => void;
+  openConfirm: (content: IConfirmContent) => void;
   closeModal: () => void;
 }
 
 const initialState: IModalState = {
   type: null,
   alertContent: null,
+  confirmContent: null,
 };
 
 export const useModalStore = create<IModalState & IModalActions>((set) => ({
   ...initialState,
-  openAlert: (content) => set({ type: 'alert', alertContent: content }),
-  openOnboarding: () => set({ type: 'onboarding', alertContent: null }),
+  openAlert: (content) => set({ type: 'alert', alertContent: content, confirmContent: null }),
+  openOnboarding: () => set({ type: 'onboarding', alertContent: null, confirmContent: null }),
+  openConfirm: (content) => set({ type: 'confirm', alertContent: null, confirmContent: content }),
   closeModal: () => set(initialState),
 }));

--- a/src/types/admin/TGetAdminAreaTypes.ts
+++ b/src/types/admin/TGetAdminAreaTypes.ts
@@ -1,0 +1,9 @@
+import type { TCommonResponse } from '@/types/common';
+
+// GET /api/admin/area-types 응답 항목 — 과목 분류 필터/폼의 이수 영역 선택지
+export type TAdminAreaType = {
+  id: number;
+  areaName: string;
+};
+
+export type TGetAdminAreaTypesResponse = TCommonResponse<TAdminAreaType[]>;

--- a/src/types/admin/TGetCourseClassifications.ts
+++ b/src/types/admin/TGetCourseClassifications.ts
@@ -1,0 +1,25 @@
+import type { TCommonResponse } from '@/types/common';
+import type { TCourseType } from '@/types/course';
+
+// GET /api/admin/course-classifications 응답 항목
+export type TAdminCourseClassification = {
+  id: number;
+  courseCode: string;
+  tag: string | null;
+  studentYearStart: number;
+  studentYearEnd: number;
+  courseType: TCourseType;
+  areaTypeId: number | null;
+  areaName: string | null;
+  subCategory: string | null;
+  subjectDomain: string | null;
+};
+
+// 과목 분류 조회 필터. 배열 값은 API 요청 직전에 콤마 문자열로 직렬화한다.
+export type TCourseClassificationFilters = {
+  areaTypeIds?: number[];
+  courseTypes?: TCourseType[];
+  years?: number[];
+};
+
+export type TGetCourseClassificationsResponse = TCommonResponse<TAdminCourseClassification[]>;

--- a/src/types/admin/TPutCourseClassifications.ts
+++ b/src/types/admin/TPutCourseClassifications.ts
@@ -1,0 +1,21 @@
+import type { TCommonResponse } from '@/types/common';
+import type { TCourseType } from '@/types/course';
+
+// PUT /api/admin/course-classifications 요청 항목
+export type TCourseClassificationUpsertItem = {
+  id: number | null;
+  courseCode: string;
+  tag: string | null;
+  studentYearStart: number;
+  studentYearEnd: number;
+  courseType: TCourseType;
+  areaTypeId: number | null;
+  subCategory: string | null;
+  subjectDomain: string | null;
+};
+
+export type TCourseClassificationUpsertRequest = {
+  items: TCourseClassificationUpsertItem[];
+};
+
+export type TPutCourseClassificationsResponse = TCommonResponse<number[]>;

--- a/src/utils/authRole.ts
+++ b/src/utils/authRole.ts
@@ -1,0 +1,47 @@
+export type TUserRole = 'STUDENT' | 'ADMIN' | 'SUPER_ADMIN';
+
+type TJwtPayload = {
+  role?: unknown;
+};
+
+const ROLE_PRIORITY: Record<TUserRole, number> = {
+  STUDENT: 0,
+  ADMIN: 1,
+  SUPER_ADMIN: 2,
+};
+
+const normalizeRole = (role: unknown): TUserRole | null => {
+  if (typeof role !== 'string') return null;
+  const normalized = role.replace(/^ROLE_/, '').toUpperCase();
+  if (normalized === 'STUDENT' || normalized === 'ADMIN' || normalized === 'SUPER_ADMIN') {
+    return normalized;
+  }
+  return null;
+};
+
+const decodeBase64Url = (value: string) => {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+  const padding = '='.repeat((4 - (normalized.length % 4)) % 4);
+  return atob(normalized + padding);
+};
+
+// 액세스 토큰의 JWT payload에서 role 클레임을 읽는다.
+// 토큰이 비어 있거나 JWT 형식이 아니면 null을 반환해 라우팅 게이트에서 차단하게 한다.
+export const getRoleFromAccessToken = (accessToken: string | null): TUserRole | null => {
+  if (!accessToken) return null;
+
+  const [, payload] = accessToken.split('.');
+  if (!payload) return null;
+
+  try {
+    const decoded = JSON.parse(decodeBase64Url(payload)) as TJwtPayload;
+    return normalizeRole(decoded.role);
+  } catch {
+    return null;
+  }
+};
+
+export const isAdminRole = (role: TUserRole | null) => {
+  if (!role) return false;
+  return ROLE_PRIORITY[role] >= ROLE_PRIORITY.ADMIN;
+};


### PR DESCRIPTION
## 📋 작업 내용
- 관리자 과목 분류 관리 UI 및 API 연동 구현

## 🎯 관련 이슈
- closes #58 

## 📝 변경 사항
- 관리자 전용 라우트와 권한 게이트를 추가
- accessToken의 role 클레임을 기준으로 ADMIN/SUPER_ADMIN 접근을 허용하도록 구현
- 관리자 계정에는 헤더 우측에 학생/관리자 전환 토글을 노출
- 관리자 헤더에 과목 관리, 졸업 요건 관리 메뉴를 추가
- 과목 분류 조회/필터/배치 업서트 API를 연동
- 과목 관리 화면에서 이수구분, 이수 영역, 입학년도 기준으로 과목 분류를 조회할 수 있게 구현
- 과목 목록에서 선택한 행과 신규 행을 상단 편집 영역에 모아 배치 수정할 수 있게 구현
- 저장 전 관리자 확인 모달을 띄워 변경 내용을 검토한 뒤 요청하도록 구현

## 📸 스크린샷 (선택사항)
<!--
필요한 경우 스크린샷 첨부
-->
