### PR TITLE
[Feat] 관리자 졸업 요건 관리 UI 및 API 연동 구현

### DIFF
--- a/src/apis/admin/graduationRequirement.ts
+++ b/src/apis/admin/graduationRequirement.ts
@@ -1,0 +1,82 @@
+import axiosInstance from '@/apis/axiosInstance';
+import type { TGetCollegesResponse, TGetDepartmentsResponse } from '@/types/admin/TGetAcademicOrganizations';
+import type { TGetGraduationRulesResponse, TGraduationRuleFilters } from '@/types/admin/TGetGraduationRules';
+import type { TGetRuleTypesResponse } from '@/types/admin/TGetRuleTypes';
+import type { TGraduationRuleUpsertRequest, TPutGraduationRulesResponse } from '@/types/admin/TPutGraduationRules';
+import type {
+  TGetRequirementSetDetailResponse,
+  TGetRequirementSetsResponse,
+  TPostRequirementSetResponse,
+  TPutRequirementSetResponse,
+  TRequirementSetCreateRequest,
+  TRequirementSetFilters,
+  TRequirementSetUpdateRequest,
+} from '@/types/admin/TRequirementSets';
+
+const joinParam = <T extends string | number>(values?: T[]) => {
+  if (!values || values.length === 0) return undefined;
+  return values.join(',');
+};
+
+// 졸업 규칙 종류 조회. ruleTypeId와 typeName 매핑 및 필터 선택지로 사용한다.
+export const getAdminRuleTypes = async () => {
+  const { data } = await axiosInstance.get<TGetRuleTypesResponse>('/api/admin/rule-types');
+  return data.result;
+};
+
+// 졸업 요건 세트 필터/등록 폼에서 사용하는 단과대 선택지 조회.
+export const getAdminColleges = async () => {
+  const { data } = await axiosInstance.get<TGetCollegesResponse>('/api/admin/colleges');
+  return data.result;
+};
+
+// 졸업 요건 세트 필터/등록 폼에서 사용하는 학과 선택지 조회.
+export const getAdminDepartments = async (collegeId?: number) => {
+  const { data } = await axiosInstance.get<TGetDepartmentsResponse>('/api/admin/departments', {
+    params: {
+      collegeId,
+    },
+  });
+  return data.result;
+};
+
+// 졸업 규칙 다중 필터 조회.
+export const getAdminGraduationRules = async (filters: TGraduationRuleFilters) => {
+  const { data } = await axiosInstance.get<TGetGraduationRulesResponse>('/api/admin/graduation-rules', {
+    params: {
+      ruleTypeIds: joinParam(filters.ruleTypeIds),
+      courseTypes: joinParam(filters.courseTypes),
+    },
+  });
+  return data.result;
+};
+
+// 졸업 규칙 배치 업서트. ruleConfig는 typeName별 폼 값으로 프론트에서 조립한다.
+export const putAdminGraduationRules = async (body: TGraduationRuleUpsertRequest) => {
+  const { data } = await axiosInstance.put<TPutGraduationRulesResponse>('/api/admin/graduation-rules', body);
+  return data.result;
+};
+
+// 졸업 요건 세트 목록 조회.
+export const getAdminRequirementSets = async (filters: TRequirementSetFilters) => {
+  const { data } = await axiosInstance.get<TGetRequirementSetsResponse>('/api/admin/requirement-sets', {
+    params: filters,
+  });
+  return data.result;
+};
+
+// 졸업 요건 세트 단건 조회. 연결된 graduationRuleIds prefill에 사용한다.
+export const getAdminRequirementSetDetail = async (id: number) => {
+  const { data } = await axiosInstance.get<TGetRequirementSetDetailResponse>(`/api/admin/requirement-sets/${id}`);
+  return data.result;
+};
+
+export const postAdminRequirementSet = async (body: TRequirementSetCreateRequest) => {
+  const { data } = await axiosInstance.post<TPostRequirementSetResponse>('/api/admin/requirement-sets', body);
+  return data.result;
+};
+
+export const putAdminRequirementSet = async (id: number, body: TRequirementSetUpdateRequest) => {
+  const { data } = await axiosInstance.put<TPutRequirementSetResponse>(`/api/admin/requirement-sets/${id}`, body);
+  return data.result;
+};

--- a/src/components/admin/adminFormControls.tsx
+++ b/src/components/admin/adminFormControls.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from 'react';
+
+// 관리자 폼/필터에서 공용으로 쓰는 입력 필드 스타일. (input·select·textarea 공통)
+export const ADMIN_INPUT_CLASS =
+  'w-full rounded-lg border border-coolgray-20 bg-white px-3 py-2 text-body-s text-coolgray-90 outline-none placeholder:text-coolgray-60 focus:border-primary-60 disabled:bg-coolgray-10 disabled:text-coolgray-60';
+
+// 네이티브 화살표를 숨긴 select(appearance-none) 위에 커스텀 꺽쇠를 칸 안쪽으로 들여 그린다.
+export function SelectChevron() {
+  return (
+    <svg
+      className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-coolgray-60"
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <path d="M5 8l5 5 5-5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+// 관리자 폼 필드의 라벨 텍스트.
+export function FieldLabel({ children }: { children: ReactNode }) {
+  return <span className="text-body-s font-semibold text-coolgray-90">{children}</span>;
+}
+
+interface ITextInputProps {
+  value: string;
+  placeholder?: string;
+  disabled: boolean;
+  onChange: (value: string) => void;
+}
+
+// 관리자 폼 공용 텍스트 입력. value/onChange만 받는 단순 제어 컴포넌트.
+export function TextInput({ value, placeholder, disabled, onChange }: ITextInputProps) {
+  return (
+    <input
+      value={value}
+      disabled={disabled}
+      placeholder={placeholder}
+      onChange={(event) => onChange(event.target.value)}
+      className={ADMIN_INPUT_CLASS}
+    />
+  );
+}

--- a/src/components/admin/courseClassificationFilters.tsx
+++ b/src/components/admin/courseClassificationFilters.tsx
@@ -65,18 +65,22 @@ export default function CourseClassificationFilters({
         <input
           value={yearInput}
           onChange={(event) => onYearInputChange(event.target.value)}
-          placeholder="예: 2023,2024"
+          placeholder="예: 2023"
           className="rounded-lg border border-coolgray-20 bg-white px-3 py-2 text-body-s text-coolgray-90 outline-none placeholder:text-coolgray-60 focus:border-primary-60"
         />
       </div>
 
       <div className="mt-auto flex justify-end gap-2">
-        <button type="button" className="rounded-full px-5 py-2 text-button-s text-coolgray-60" onClick={onReset}>
+        <button
+          type="button"
+          className="rounded-full px-5 py-2 text-button-s text-coolgray-60 cursor-pointer"
+          onClick={onReset}
+        >
           초기화
         </button>
         <button
           type="button"
-          className="rounded-full bg-primary-60 px-5 py-2 text-button-s text-white hover:opacity-90"
+          className="rounded-full bg-primary-60 px-5 py-2 text-button-s text-white hover:opacity-90 cursor-pointer"
           onClick={onApply}
         >
           필터 적용

--- a/src/components/admin/courseClassificationFormRow.tsx
+++ b/src/components/admin/courseClassificationFormRow.tsx
@@ -1,3 +1,4 @@
+import { ADMIN_INPUT_CLASS, SelectChevron } from '@/components/admin/adminFormControls';
 import type {
   TCourseClassificationDraft,
   TCourseClassificationFormState,
@@ -5,25 +6,9 @@ import type {
 import type { TAdminAreaType } from '@/types/admin/TGetAdminAreaTypes';
 import { COURSE_LABEL, COURSE_TYPES } from '@/types/course';
 
-const INPUT_CLASS =
-  'w-full rounded-lg border border-coolgray-20 bg-white px-3 py-2 text-body-s text-coolgray-90 outline-none placeholder:text-coolgray-60 focus:border-primary-60 disabled:bg-coolgray-10 disabled:text-coolgray-60';
+const INPUT_CLASS = ADMIN_INPUT_CLASS;
 
 const BODY_CELL_CLASS = 'px-3 py-3 align-top';
-
-// 네이티브 화살표를 숨긴 select(appearance-none) 위에 커스텀 꺽쇠를 칸 안쪽으로 들여 그린다.
-function SelectChevron() {
-  return (
-    <svg
-      className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-coolgray-60"
-      viewBox="0 0 20 20"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-    >
-      <path d="M5 8l5 5 5-5" strokeLinecap="round" strokeLinejoin="round" />
-    </svg>
-  );
-}
 
 interface ICourseClassificationFormRowProps {
   draft: TCourseClassificationDraft;
@@ -53,6 +38,7 @@ export default function CourseClassificationFormRow({
         <input
           value={draft.courseCode}
           disabled={isSaving}
+          placeholder="RGC0003"
           onChange={(event) => onChange(draft.clientId, 'courseCode', event.target.value)}
           className={INPUT_CLASS}
         />
@@ -61,6 +47,7 @@ export default function CourseClassificationFormRow({
         <input
           value={draft.tag}
           disabled={isSaving}
+          placeholder="불교와인간"
           onChange={(event) => onChange(draft.clientId, 'tag', event.target.value)}
           className={INPUT_CLASS}
         />
@@ -70,6 +57,7 @@ export default function CourseClassificationFormRow({
           value={draft.studentYearStart}
           disabled={isSaving}
           inputMode="numeric"
+          placeholder="2023"
           onChange={(event) => onChange(draft.clientId, 'studentYearStart', event.target.value)}
           className={INPUT_CLASS}
         />
@@ -79,6 +67,7 @@ export default function CourseClassificationFormRow({
           value={draft.studentYearEnd}
           disabled={isSaving}
           inputMode="numeric"
+          placeholder="2023"
           onChange={(event) => onChange(draft.clientId, 'studentYearEnd', event.target.value)}
           className={INPUT_CLASS}
         />
@@ -123,6 +112,7 @@ export default function CourseClassificationFormRow({
         <input
           value={draft.subCategory}
           disabled={isSaving}
+          placeholder="필수"
           onChange={(event) => onChange(draft.clientId, 'subCategory', event.target.value)}
           className={INPUT_CLASS}
         />
@@ -131,6 +121,7 @@ export default function CourseClassificationFormRow({
         <input
           value={draft.subjectDomain}
           disabled={isSaving}
+          placeholder="공통교양"
           onChange={(event) => onChange(draft.clientId, 'subjectDomain', event.target.value)}
           className={INPUT_CLASS}
         />

--- a/src/components/admin/graduationRuleConfigFields.tsx
+++ b/src/components/admin/graduationRuleConfigFields.tsx
@@ -1,0 +1,268 @@
+import { ADMIN_INPUT_CLASS, FieldLabel, SelectChevron, TextInput } from '@/components/admin/adminFormControls';
+import type {
+  TGraduationRuleDraft,
+  TGraduationRuleDraftField,
+  TGraduationRuleDraftValue,
+} from '@/components/admin/graduationRuleForm';
+import MultiSelectDropdown from '@/components/admin/multiSelectDropdown';
+import type { TAdminAreaType } from '@/types/admin/TGetAdminAreaTypes';
+import type { TAdminRuleType } from '@/types/admin/TGetRuleTypes';
+import { COURSE_LABEL, COURSE_TYPES, type TCourseType } from '@/types/course';
+
+const COURSE_TYPE_OPTIONS = COURSE_TYPES.map((courseType) => ({ value: courseType, label: COURSE_LABEL[courseType] }));
+
+interface IGraduationRuleConfigFieldsProps {
+  selectedRuleType: TAdminRuleType | null;
+  draft: TGraduationRuleDraft;
+  areaTypes: TAdminAreaType[];
+  isSaving: boolean;
+  // 이미 clientId가 바인딩된 변경 핸들러. 필드와 값만 넘기면 된다.
+  onFieldChange: (field: TGraduationRuleDraftField, value: TGraduationRuleDraftValue) => void;
+}
+
+// 규칙 종류(typeName)에 따라 달라지는 ruleConfig 입력칸. 종류별로 필요한 필드만 노출한다.
+export default function GraduationRuleConfigFields({
+  selectedRuleType,
+  draft,
+  areaTypes,
+  isSaving,
+  onFieldChange,
+}: IGraduationRuleConfigFieldsProps) {
+  const areaNameOptions = areaTypes.map((areaType) => ({ value: areaType.areaName, label: areaType.areaName }));
+
+  const toggleAreaName = (areaName: string) => {
+    onFieldChange(
+      'areaNames',
+      draft.areaNames.includes(areaName)
+        ? draft.areaNames.filter((value) => value !== areaName)
+        : [...draft.areaNames, areaName],
+    );
+  };
+
+  const toggleCourseType = (courseType: TCourseType) => {
+    onFieldChange(
+      'courseTypes',
+      draft.courseTypes.includes(courseType)
+        ? draft.courseTypes.filter((value) => value !== courseType)
+        : [...draft.courseTypes, courseType],
+    );
+  };
+
+  return (
+    <div className="mt-4 rounded-xl bg-primary-30/40 p-4">
+      {!selectedRuleType && (
+        <p className="text-body-s text-coolgray-60">규칙 종류를 선택하면 설정 입력칸이 나타납니다.</p>
+      )}
+
+      {selectedRuleType?.typeName === 'TOTAL_CREDITS' && (
+        <label className="flex max-w-xs flex-col gap-1.5">
+          <FieldLabel>최소 취득학점</FieldLabel>
+          <TextInput
+            value={draft.minCredits}
+            disabled={isSaving}
+            placeholder="130"
+            onChange={(value) => onFieldChange('minCredits', value)}
+          />
+        </label>
+      )}
+
+      {selectedRuleType?.typeName === 'GPA' && (
+        <label className="flex max-w-xs flex-col gap-1.5">
+          <FieldLabel>최소 평점평균</FieldLabel>
+          <TextInput
+            value={draft.minGpa}
+            disabled={isSaving}
+            placeholder="2.0"
+            onChange={(value) => onFieldChange('minGpa', value)}
+          />
+        </label>
+      )}
+
+      {selectedRuleType?.typeName === 'MIN_AREA_CREDITS' && (
+        <div className="grid gap-3 md:grid-cols-3">
+          <label className="flex flex-col gap-1.5">
+            <FieldLabel>이수구분</FieldLabel>
+            <div className="relative">
+              <select
+                value={draft.courseType}
+                disabled={isSaving}
+                onChange={(event) => onFieldChange('courseType', event.target.value)}
+                className={`${ADMIN_INPUT_CLASS} appearance-none pr-8`}
+              >
+                <option value="">선택</option>
+                {COURSE_TYPES.map((courseType) => (
+                  <option key={courseType} value={courseType}>
+                    {COURSE_LABEL[courseType]}
+                  </option>
+                ))}
+              </select>
+              <SelectChevron />
+            </div>
+          </label>
+          <label className="flex flex-col gap-1.5">
+            <FieldLabel>영역명</FieldLabel>
+            <MultiSelectDropdown
+              options={areaNameOptions}
+              selectedValues={draft.areaNames}
+              onToggle={toggleAreaName}
+              allLabel="전체 영역"
+              disabled={isSaving}
+            />
+          </label>
+          <label className="flex flex-col gap-1.5">
+            <FieldLabel>최소 학점</FieldLabel>
+            <TextInput
+              value={draft.minCredits}
+              disabled={isSaving}
+              placeholder="17"
+              onChange={(value) => onFieldChange('minCredits', value)}
+            />
+          </label>
+        </div>
+      )}
+
+      {selectedRuleType?.typeName === 'REQUIRED_COURSE' && (
+        <div className="grid gap-3 md:grid-cols-3">
+          <label className="flex flex-col gap-1.5">
+            <FieldLabel>필수 과목코드</FieldLabel>
+            <TextInput
+              value={draft.courseCodes}
+              disabled={isSaving}
+              placeholder="RGC0003"
+              onChange={(value) => onFieldChange('courseCodes', value)}
+            />
+          </label>
+          <label className="flex flex-col gap-1.5">
+            <FieldLabel>면제 영어레벨</FieldLabel>
+            <TextInput
+              value={draft.exemptEnglishLevels}
+              disabled={isSaving}
+              placeholder="S0, S4"
+              onChange={(value) => onFieldChange('exemptEnglishLevels', value)}
+            />
+          </label>
+          <label className="flex flex-col gap-1.5">
+            <FieldLabel>적용 영어레벨</FieldLabel>
+            <TextInput
+              value={draft.requiredEnglishLevels}
+              disabled={isSaving}
+              placeholder="S4"
+              onChange={(value) => onFieldChange('requiredEnglishLevels', value)}
+            />
+          </label>
+        </div>
+      )}
+
+      {selectedRuleType?.typeName === 'ENGLISH_COURSE' && (
+        <div className="grid gap-3 md:grid-cols-2">
+          <label className="flex flex-col gap-1.5">
+            <FieldLabel>대상 이수구분</FieldLabel>
+            <MultiSelectDropdown
+              options={COURSE_TYPE_OPTIONS}
+              selectedValues={draft.courseTypes}
+              onToggle={toggleCourseType}
+              allLabel="전체 이수구분"
+              disabled={isSaving}
+            />
+          </label>
+          <label className="flex flex-col gap-1.5">
+            <FieldLabel>최소 이수 개수</FieldLabel>
+            <TextInput
+              value={draft.minCount}
+              disabled={isSaving}
+              placeholder="2"
+              onChange={(value) => onFieldChange('minCount', value)}
+            />
+          </label>
+        </div>
+      )}
+
+      {selectedRuleType?.typeName === 'PREREQUISITE' && (
+        <div className="grid gap-3 md:grid-cols-2">
+          <label className="flex flex-col gap-1.5">
+            <FieldLabel>대상 과목코드</FieldLabel>
+            <TextInput
+              value={draft.targetCourseCodes}
+              disabled={isSaving}
+              placeholder="RGC1081"
+              onChange={(value) => onFieldChange('targetCourseCodes', value)}
+            />
+          </label>
+          <label className="flex flex-col gap-1.5">
+            <FieldLabel>선이수 과목코드</FieldLabel>
+            <TextInput
+              value={draft.prerequisiteCourseCodes}
+              disabled={isSaving}
+              placeholder="RGC1080"
+              onChange={(value) => onFieldChange('prerequisiteCourseCodes', value)}
+            />
+          </label>
+          <label className="flex flex-col gap-1.5">
+            <FieldLabel>조건 필드</FieldLabel>
+            <div className="relative">
+              <select
+                value={draft.conditionField}
+                disabled={isSaving}
+                onChange={(event) => onFieldChange('conditionField', event.target.value)}
+                className={`${ADMIN_INPUT_CLASS} appearance-none pr-8`}
+              >
+                <option value="">없음</option>
+                <option value="englishLevel">영어 레벨</option>
+              </select>
+              <SelectChevron />
+            </div>
+          </label>
+          <label className="flex flex-col gap-1.5">
+            <FieldLabel>조건 값</FieldLabel>
+            <TextInput
+              value={draft.conditionValue}
+              disabled={isSaving}
+              placeholder="S4"
+              onChange={(value) => onFieldChange('conditionValue', value)}
+            />
+          </label>
+        </div>
+      )}
+
+      {selectedRuleType?.typeName === 'SCIENCE_EXPERIMENT' && (
+        <label className="flex max-w-xs flex-col gap-1.5">
+          <FieldLabel>최소 이수 개수</FieldLabel>
+          <TextInput
+            value={draft.minCount}
+            disabled={isSaving}
+            placeholder="1"
+            onChange={(value) => onFieldChange('minCount', value)}
+          />
+        </label>
+      )}
+
+      {selectedRuleType?.typeName === 'SCIENCE_CONFLICT' && (
+        <p className="text-body-s text-coolgray-60">입력값이 없는 고정 규칙입니다. 저장 시 빈 객체가 전송됩니다.</p>
+      )}
+
+      {selectedRuleType?.typeName === 'THESIS' && (
+        <div className="grid gap-3">
+          <label className="flex flex-col gap-1.5">
+            <FieldLabel>면제 학생유형</FieldLabel>
+            <TextInput
+              value={draft.exemptStudentTypes}
+              disabled={isSaving}
+              placeholder="학석사연계과정"
+              onChange={(value) => onFieldChange('exemptStudentTypes', value)}
+            />
+          </label>
+          <label className="flex flex-col gap-1.5">
+            <FieldLabel>필수 과목 세트</FieldLabel>
+            <textarea
+              value={draft.requiredCourseSetsText}
+              disabled={isSaving}
+              placeholder={'한 줄이 하나의 세트입니다.\n예: CSE4066,CSC4018 | CSE4067,CSC4019'}
+              onChange={(event) => onFieldChange('requiredCourseSetsText', event.target.value)}
+              className={`${ADMIN_INPUT_CLASS} min-h-24 resize-y`}
+            />
+          </label>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/admin/graduationRuleFilters.tsx
+++ b/src/components/admin/graduationRuleFilters.tsx
@@ -1,0 +1,77 @@
+import MultiSelectDropdown from '@/components/admin/multiSelectDropdown';
+import type { TAdminRuleType } from '@/types/admin/TGetRuleTypes';
+import { COURSE_LABEL, COURSE_TYPES, type TCourseType } from '@/types/course';
+
+interface IGraduationRuleFiltersProps {
+  ruleTypes: TAdminRuleType[];
+  selectedRuleTypeIds: number[];
+  selectedCourseTypes: TCourseType[];
+  onRuleTypeToggle: (ruleTypeId: number) => void;
+  onCourseTypeToggle: (courseType: TCourseType) => void;
+  onApply: () => void;
+  onReset: () => void;
+}
+
+export default function GraduationRuleFilters({
+  ruleTypes,
+  selectedRuleTypeIds,
+  selectedCourseTypes,
+  onRuleTypeToggle,
+  onCourseTypeToggle,
+  onApply,
+  onReset,
+}: IGraduationRuleFiltersProps) {
+  const ruleTypeOptions = ruleTypes.map((ruleType) => ({
+    value: ruleType.id,
+    label: `${ruleType.typeName}${ruleType.description ? ` · ${ruleType.description}` : ''}`,
+  }));
+  const courseTypeOptions = COURSE_TYPES.map((courseType) => ({ value: courseType, label: COURSE_LABEL[courseType] }));
+
+  return (
+    <section className="flex h-full flex-col gap-5 rounded-2xl border border-coolgray-10 bg-white p-8 shadow-sm">
+      <div>
+        <h2 className="text-heading-5 text-coolgray-90">졸업 규칙 필터</h2>
+        <p className="mt-1 text-body-s text-coolgray-60">
+          규칙 종류와 이수구분을 다중 선택해 조회합니다. 미선택 시 전체를 조회합니다.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="flex flex-col gap-1.5">
+          <span className="text-body-s font-semibold text-coolgray-90">규칙 종류</span>
+          <MultiSelectDropdown
+            options={ruleTypeOptions}
+            selectedValues={selectedRuleTypeIds}
+            onToggle={onRuleTypeToggle}
+          />
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <span className="text-body-s font-semibold text-coolgray-90">이수구분</span>
+          <MultiSelectDropdown
+            options={courseTypeOptions}
+            selectedValues={selectedCourseTypes}
+            onToggle={onCourseTypeToggle}
+          />
+        </div>
+      </div>
+
+      <div className="mt-auto flex justify-end gap-2">
+        <button
+          type="button"
+          className="rounded-full px-5 py-2 text-button-s text-coolgray-60 cursor-pointer"
+          onClick={onReset}
+        >
+          초기화
+        </button>
+        <button
+          type="button"
+          className="rounded-full bg-primary-60 px-5 py-2 text-button-s text-white hover:opacity-90 cursor-pointer"
+          onClick={onApply}
+        >
+          필터 적용
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/components/admin/graduationRuleForm.tsx
+++ b/src/components/admin/graduationRuleForm.tsx
@@ -1,0 +1,206 @@
+import { ADMIN_INPUT_CLASS, FieldLabel, SelectChevron, TextInput } from '@/components/admin/adminFormControls';
+import GraduationRuleConfigFields from '@/components/admin/graduationRuleConfigFields';
+import Button from '@/components/common/button';
+import type { TAdminAreaType } from '@/types/admin/TGetAdminAreaTypes';
+import type { TAdminRuleType } from '@/types/admin/TGetRuleTypes';
+import type { TCourseType } from '@/types/course';
+
+export type TGraduationRuleDraft = {
+  clientId: string;
+  id: number | null;
+  ruleTypeId: string;
+  ruleName: string;
+  description: string;
+  minCredits: string;
+  minGpa: string;
+  minCount: string;
+  courseType: TCourseType | '';
+  areaNames: string[];
+  courseCodes: string;
+  exemptEnglishLevels: string;
+  requiredEnglishLevels: string;
+  courseTypes: TCourseType[];
+  targetCourseCodes: string;
+  prerequisiteCourseCodes: string;
+  conditionField: '' | 'englishLevel';
+  conditionValue: string;
+  exemptStudentTypes: string;
+  requiredCourseSetsText: string;
+};
+
+export type TGraduationRuleDraftField = keyof TGraduationRuleDraft;
+export type TGraduationRuleDraftValue = string | string[] | TCourseType[];
+
+interface IGraduationRuleFormProps {
+  areaTypes: TAdminAreaType[];
+  ruleTypes: TAdminRuleType[];
+  drafts: TGraduationRuleDraft[];
+  isSaving: boolean;
+  onAddNew: () => void;
+  onRemove: (clientId: string) => void;
+  onChange: (clientId: string, field: TGraduationRuleDraftField, value: TGraduationRuleDraftValue) => void;
+  onSubmit: () => void;
+}
+
+const toRuleTypeLabel = (ruleType: TAdminRuleType) => {
+  if (!ruleType.description) return ruleType.typeName;
+  return `${ruleType.typeName} · ${ruleType.description}`;
+};
+
+interface IGraduationRuleFormRowProps {
+  areaTypes: TAdminAreaType[];
+  ruleTypes: TAdminRuleType[];
+  draft: TGraduationRuleDraft;
+  isSaving: boolean;
+  onRemove: (clientId: string) => void;
+  onChange: (clientId: string, field: TGraduationRuleDraftField, value: TGraduationRuleDraftValue) => void;
+}
+
+function GraduationRuleFormRow({
+  areaTypes,
+  ruleTypes,
+  draft,
+  isSaving,
+  onRemove,
+  onChange,
+}: IGraduationRuleFormRowProps) {
+  const selectedRuleType = ruleTypes.find((ruleType) => String(ruleType.id) === draft.ruleTypeId) ?? null;
+
+  // clientId를 미리 바인딩한 변경 핸들러. 공통 필드와 설정 필드에서 공유한다.
+  const update = (field: TGraduationRuleDraftField, value: TGraduationRuleDraftValue) => {
+    onChange(draft.clientId, field, value);
+  };
+
+  return (
+    <div className="rounded-xl border border-coolgray-10 bg-white p-5">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-center gap-2">
+          <span className="rounded-full bg-primary-30 px-3 py-1 text-body-xs font-semibold text-primary-90">
+            {draft.id === null ? '신규' : '수정'}
+          </span>
+          {draft.id !== null && <span className="text-body-s text-coolgray-60">ID {draft.id}</span>}
+        </div>
+        <button
+          type="button"
+          disabled={isSaving}
+          onClick={() => onRemove(draft.clientId)}
+          className="rounded-full px-2 py-1 text-body-s text-coolgray-60 hover:text-primary-60 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          삭제
+        </button>
+      </div>
+
+      <div className="mt-4 grid gap-4 lg:grid-cols-[1.1fr_1fr_1fr]">
+        <label className="flex flex-col gap-1.5">
+          <FieldLabel>규칙 종류</FieldLabel>
+          <div className="relative">
+            <select
+              value={draft.ruleTypeId}
+              disabled={isSaving}
+              onChange={(event) => update('ruleTypeId', event.target.value)}
+              className={`${ADMIN_INPUT_CLASS} appearance-none pr-8`}
+            >
+              <option value="">선택</option>
+              {ruleTypes.map((ruleType) => (
+                <option key={ruleType.id} value={ruleType.id}>
+                  {toRuleTypeLabel(ruleType)}
+                </option>
+              ))}
+            </select>
+            <SelectChevron />
+          </div>
+        </label>
+
+        <label className="flex flex-col gap-1.5">
+          <FieldLabel>규칙명</FieldLabel>
+          <TextInput
+            value={draft.ruleName}
+            disabled={isSaving}
+            placeholder="총 취득학점이 130학점 이상이어야 합니다."
+            onChange={(value) => update('ruleName', value)}
+          />
+        </label>
+
+        <label className="flex flex-col gap-1.5">
+          <FieldLabel>설명</FieldLabel>
+          <TextInput
+            value={draft.description}
+            disabled={isSaving}
+            placeholder="총 취득학점 규칙"
+            onChange={(value) => update('description', value)}
+          />
+        </label>
+      </div>
+
+      <GraduationRuleConfigFields
+        selectedRuleType={selectedRuleType}
+        draft={draft}
+        areaTypes={areaTypes}
+        isSaving={isSaving}
+        onFieldChange={update}
+      />
+    </div>
+  );
+}
+
+export default function GraduationRuleForm({
+  areaTypes,
+  ruleTypes,
+  drafts,
+  isSaving,
+  onAddNew,
+  onRemove,
+  onChange,
+  onSubmit,
+}: IGraduationRuleFormProps) {
+  return (
+    <section className="flex flex-col gap-5 rounded-2xl border border-coolgray-10 bg-white p-8 shadow-sm">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-heading-5 text-coolgray-90">졸업 규칙 수정</h2>
+          <p className="mt-1 text-body-s text-coolgray-60">
+            규칙 종류별 입력값을 채우면 프론트가 API 스키마에 맞는 ruleConfig를 조립합니다.
+          </p>
+        </div>
+        <div className="flex gap-4">
+          <Button
+            variant={isSaving ? 'disabled' : 'outlined'}
+            disabled={isSaving}
+            onClick={onAddNew}
+            className="w-20 py-3.5"
+          >
+            신규
+          </Button>
+          <Button
+            variant={drafts.length > 0 && !isSaving ? 'primary' : 'disabled'}
+            disabled={drafts.length === 0 || isSaving}
+            onClick={onSubmit}
+            className="w-28 py-3.5"
+          >
+            수정하기
+          </Button>
+        </div>
+      </div>
+
+      {drafts.length === 0 ? (
+        <div className="rounded-xl border border-coolgray-10 px-4 py-10 text-center text-body-m text-coolgray-60">
+          수정할 규칙을 선택하거나 신규 행을 추가해주세요.
+        </div>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {drafts.map((draft) => (
+            <GraduationRuleFormRow
+              key={draft.clientId}
+              areaTypes={areaTypes}
+              ruleTypes={ruleTypes}
+              draft={draft}
+              isSaving={isSaving}
+              onChange={onChange}
+              onRemove={onRemove}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/admin/graduationRuleTable.tsx
+++ b/src/components/admin/graduationRuleTable.tsx
@@ -1,0 +1,140 @@
+import type { TAdminGraduationRule } from '@/types/admin/TGetGraduationRules';
+import { COURSE_LABEL } from '@/types/course';
+
+interface IGraduationRuleTableProps {
+  rules: TAdminGraduationRule[];
+  selectedIds: Set<number>;
+  isLoading: boolean;
+  isError: boolean;
+  mode: 'rule' | 'set';
+  onToggleAll: (checked: boolean) => void;
+  onToggleRow: (ruleId: number, checked: boolean) => void;
+}
+
+const HEADER_CELL_CLASS = 'px-4 py-3 text-left text-body-s font-semibold text-primary-90';
+const BODY_CELL_CLASS = 'px-4 py-4 text-body-s text-coolgray-90';
+
+const formatConfig = (config: Record<string, unknown>) => {
+  const entries = Object.entries(config);
+  if (entries.length === 0) return '{}';
+  return entries
+    .map(([key, value]) => {
+      if (Array.isArray(value)) return `${key}: ${value.flat(3).join(', ') || '[]'}`;
+      if (value === null || value === undefined) return `${key}: null`;
+      return `${key}: ${String(value)}`;
+    })
+    .join(' · ');
+};
+
+export default function GraduationRuleTable({
+  rules,
+  selectedIds,
+  isLoading,
+  isError,
+  mode,
+  onToggleAll,
+  onToggleRow,
+}: IGraduationRuleTableProps) {
+  const allChecked = rules.length > 0 && rules.every((rule) => selectedIds.has(rule.id));
+  const selectionLabel = mode === 'rule' ? '편집' : '세트 선택';
+
+  return (
+    <section className="flex flex-col gap-5 rounded-2xl border border-coolgray-10 bg-white p-8 shadow-sm">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-heading-5 text-coolgray-90">졸업 규칙 목록</h2>
+          <p className="mt-1 text-body-s text-coolgray-60">조회 결과 {rules.length.toLocaleString()}건</p>
+        </div>
+        <span className="rounded-full bg-primary-30 px-4 py-2 text-button-s text-primary-90">
+          {selectionLabel} {selectedIds.size.toLocaleString()}건
+        </span>
+      </div>
+
+      <div className="max-h-[590px] overflow-auto rounded-xl border border-coolgray-10">
+        <table className="min-w-[1120px] w-full table-fixed border-collapse bg-white">
+          <colgroup>
+            <col className="w-12" />
+            <col className="w-[22%]" />
+            <col className="w-[18%]" />
+            <col className="w-[12%]" />
+            <col className="w-[30%]" />
+            <col className="w-[18%]" />
+          </colgroup>
+          <thead className="sticky top-0 z-10 bg-primary-30">
+            <tr>
+              <th className="px-4 py-3 text-left">
+                <input
+                  type="checkbox"
+                  checked={allChecked}
+                  disabled={rules.length === 0}
+                  onChange={(event) => onToggleAll(event.target.checked)}
+                  className="h-4 w-4 accent-primary-60"
+                  aria-label="전체 졸업 규칙 선택"
+                />
+              </th>
+              <th className={HEADER_CELL_CLASS}>규칙명</th>
+              <th className={HEADER_CELL_CLASS}>규칙 종류</th>
+              <th className={HEADER_CELL_CLASS}>이수구분</th>
+              <th className={HEADER_CELL_CLASS}>설정값</th>
+              <th className={HEADER_CELL_CLASS}>설명</th>
+            </tr>
+          </thead>
+          <tbody>
+            {isLoading && (
+              <tr>
+                <td colSpan={6} className="px-4 py-16 text-center text-body-m text-coolgray-60">
+                  졸업 규칙을 불러오는 중입니다.
+                </td>
+              </tr>
+            )}
+            {isError && !isLoading && (
+              <tr>
+                <td colSpan={6} className="px-4 py-16 text-center text-body-m text-alert">
+                  졸업 규칙을 불러오지 못했어요.
+                </td>
+              </tr>
+            )}
+            {!isLoading && !isError && rules.length === 0 && (
+              <tr>
+                <td colSpan={6} className="px-4 py-16 text-center text-body-m text-coolgray-60">
+                  조건에 맞는 졸업 규칙이 없습니다.
+                </td>
+              </tr>
+            )}
+            {!isLoading &&
+              !isError &&
+              rules.map((rule) => (
+                <tr
+                  key={rule.id}
+                  className={`border-t border-coolgray-10 transition-colors ${
+                    selectedIds.has(rule.id) ? 'bg-primary-30/70' : 'hover:bg-coolgray-10/50'
+                  }`}
+                >
+                  <td className="px-4 py-4">
+                    <input
+                      type="checkbox"
+                      checked={selectedIds.has(rule.id)}
+                      onChange={(event) => onToggleRow(rule.id, event.target.checked)}
+                      className="h-4 w-4 accent-primary-60"
+                      aria-label={`${rule.ruleName} 선택`}
+                    />
+                  </td>
+                  <td className={`${BODY_CELL_CLASS} font-semibold`}>
+                    <span className="block truncate">{rule.ruleName}</span>
+                  </td>
+                  <td className={BODY_CELL_CLASS}>{rule.typeName}</td>
+                  <td className={BODY_CELL_CLASS}>{rule.courseType ? COURSE_LABEL[rule.courseType] : '전체'}</td>
+                  <td className={BODY_CELL_CLASS}>
+                    <span className="block truncate">{formatConfig(rule.ruleConfig)}</span>
+                  </td>
+                  <td className={BODY_CELL_CLASS}>
+                    <span className="block truncate">{rule.description ?? '-'}</span>
+                  </td>
+                </tr>
+              ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/src/components/admin/requirementSetFilters.tsx
+++ b/src/components/admin/requirementSetFilters.tsx
@@ -1,0 +1,102 @@
+import { ADMIN_INPUT_CLASS } from '@/components/admin/adminFormControls';
+import type { TAdminCollege, TAdminDepartment } from '@/types/admin/TGetAcademicOrganizations';
+
+interface IRequirementSetFiltersProps {
+  colleges: TAdminCollege[];
+  departments: TAdminDepartment[];
+  selectedCollegeId: string;
+  selectedDepartmentId: string;
+  yearInput: string;
+  isLoadingDepartments: boolean;
+  onCollegeChange: (value: string) => void;
+  onDepartmentChange: (value: string) => void;
+  onYearChange: (value: string) => void;
+  onApply: () => void;
+  onReset: () => void;
+}
+
+const INPUT_CLASS = ADMIN_INPUT_CLASS;
+
+export default function RequirementSetFilters({
+  colleges,
+  departments,
+  selectedCollegeId,
+  selectedDepartmentId,
+  yearInput,
+  isLoadingDepartments,
+  onCollegeChange,
+  onDepartmentChange,
+  onYearChange,
+  onApply,
+  onReset,
+}: IRequirementSetFiltersProps) {
+  return (
+    <section className="flex h-full flex-col gap-5 rounded-2xl border border-coolgray-10 bg-white p-8 shadow-sm">
+      <div>
+        <h2 className="text-heading-5 text-coolgray-90">졸업 세트 필터</h2>
+        <p className="mt-1 text-body-s text-coolgray-60">단과대, 학과, 적용 연도로 기존 졸업 요건 세트를 조회합니다.</p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <label className="flex flex-col gap-1.5">
+          <span className="text-body-s font-semibold text-coolgray-90">단과대</span>
+          <select
+            value={selectedCollegeId}
+            onChange={(event) => onCollegeChange(event.target.value)}
+            className={INPUT_CLASS}
+          >
+            <option value="">전체 단과대</option>
+            {colleges.map((college) => (
+              <option key={college.id} value={college.id}>
+                {college.collegeName}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1.5">
+          <span className="text-body-s font-semibold text-coolgray-90">학과</span>
+          <select
+            value={selectedDepartmentId}
+            disabled={isLoadingDepartments}
+            onChange={(event) => onDepartmentChange(event.target.value)}
+            className={INPUT_CLASS}
+          >
+            <option value="">{isLoadingDepartments ? '학과 불러오는 중' : '전체 학과'}</option>
+            {departments.map((department) => (
+              <option key={department.id} value={department.id}>
+                {department.departmentName}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1.5">
+          <span className="text-body-s font-semibold text-coolgray-90">적용 연도</span>
+          <input
+            value={yearInput}
+            inputMode="numeric"
+            placeholder="예: 2023"
+            onChange={(event) => onYearChange(event.target.value)}
+            className={INPUT_CLASS}
+          />
+        </label>
+      </div>
+
+      <div className="mt-auto flex justify-end gap-2">
+        <button
+          type="button"
+          className="rounded-full px-5 py-2 text-button-s text-coolgray-60 cursor-pointer"
+          onClick={onReset}
+        >
+          초기화
+        </button>
+        <button
+          type="button"
+          className="rounded-full bg-primary-60 px-5 py-2 text-button-s text-white hover:opacity-90 cursor-pointer"
+          onClick={onApply}
+        >
+          필터 적용
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/components/admin/requirementSetForm.tsx
+++ b/src/components/admin/requirementSetForm.tsx
@@ -1,0 +1,206 @@
+import { ADMIN_INPUT_CLASS } from '@/components/admin/adminFormControls';
+import Button from '@/components/common/button';
+import type { TAdminCollege, TAdminDepartment } from '@/types/admin/TGetAcademicOrganizations';
+import type { TAdminRequirementSetSummary } from '@/types/admin/TRequirementSets';
+
+export type TRequirementSetFormState = {
+  id: number | null;
+  departmentId: number | null;
+  collegeName: string;
+  departmentName: string;
+  yearStart: string;
+  yearEnd: string;
+  version: string;
+  description: string;
+  sheetImageUrl: string;
+  active: boolean;
+};
+
+interface IRequirementSetFormProps {
+  colleges: TAdminCollege[];
+  departments: TAdminDepartment[];
+  sets: TAdminRequirementSetSummary[];
+  selectedRuleCount: number;
+  form: TRequirementSetFormState;
+  isSaving: boolean;
+  isLoadingDetail: boolean;
+  onChange: (field: keyof TRequirementSetFormState, value: string | boolean | number | null) => void;
+  onNew: () => void;
+  onLoadSet: (setId: number) => void;
+  onSubmit: () => void;
+}
+
+const INPUT_CLASS = ADMIN_INPUT_CLASS;
+
+export default function RequirementSetForm({
+  colleges,
+  departments,
+  sets,
+  selectedRuleCount,
+  form,
+  isSaving,
+  isLoadingDetail,
+  onChange,
+  onNew,
+  onLoadSet,
+  onSubmit,
+}: IRequirementSetFormProps) {
+  const isEditMode = form.id !== null;
+
+  return (
+    <section className="flex flex-col gap-5 rounded-2xl border border-coolgray-10 bg-white p-8 shadow-sm">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-heading-5 text-coolgray-90">졸업 세트 관리</h2>
+          <p className="mt-1 text-body-s text-coolgray-60">
+            아래 졸업 규칙 목록에서 선택한 규칙 {selectedRuleCount}건으로 요건 세트를 저장합니다.
+          </p>
+        </div>
+        <div className="flex gap-4">
+          <Button
+            variant={isSaving ? 'disabled' : 'outlined'}
+            disabled={isSaving}
+            onClick={onNew}
+            className="w-20 py-3.5"
+          >
+            신규
+          </Button>
+          <Button
+            variant={selectedRuleCount > 0 && !isSaving ? 'primary' : 'disabled'}
+            disabled={selectedRuleCount === 0 || isSaving}
+            onClick={onSubmit}
+            className="w-28 py-3.5"
+          >
+            저장하기
+          </Button>
+        </div>
+      </div>
+
+      <div className="rounded-xl bg-primary-30/50 px-5 py-4 text-body-s text-coolgray-90">
+        <p className="font-semibold text-primary-90">버전·활성 정책</p>
+        <p className="mt-1">
+          버전은 서버가 자동 채번하므로 입력하지 않습니다. 활성 세트는 같은 학과에서 적용년도가 겹치면 저장이 거부되며,
+          비활성 세트끼리는 겹쳐도 함께 둘 수 있습니다.
+        </p>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-[1fr_1fr_1fr]">
+        <label className="flex flex-col gap-1.5">
+          <span className="text-body-s font-semibold text-coolgray-90">기존 세트 불러오기</span>
+          <select
+            value={form.id ?? ''}
+            disabled={isSaving || isLoadingDetail}
+            onChange={(event) => {
+              if (!event.target.value) return;
+              onLoadSet(Number(event.target.value));
+            }}
+            className={INPUT_CLASS}
+          >
+            <option value="">선택</option>
+            {sets.map((set) => (
+              <option key={set.id} value={set.id}>
+                {set.departmentName} · {set.yearStart}-{set.yearEnd} · v{set.version}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex flex-col gap-1.5">
+          <span className="text-body-s font-semibold text-coolgray-90">단과대</span>
+          <input
+            value={form.collegeName}
+            disabled={isSaving || isEditMode}
+            list="admin-college-options"
+            placeholder="예: 첨단융합대학"
+            onChange={(event) => onChange('collegeName', event.target.value)}
+            className={INPUT_CLASS}
+          />
+          <datalist id="admin-college-options">
+            {colleges.map((college) => (
+              <option key={college.id} value={college.collegeName} />
+            ))}
+          </datalist>
+        </label>
+
+        <label className="flex flex-col gap-1.5">
+          <span className="text-body-s font-semibold text-coolgray-90">학과</span>
+          <input
+            value={form.departmentName}
+            disabled={isSaving || isEditMode}
+            list="admin-department-options"
+            placeholder="예: 컴퓨터·AI학부"
+            onChange={(event) => onChange('departmentName', event.target.value)}
+            className={INPUT_CLASS}
+          />
+          <datalist id="admin-department-options">
+            {departments.map((department) => (
+              <option key={department.id} value={department.departmentName} />
+            ))}
+          </datalist>
+        </label>
+
+        <label className="flex flex-col gap-1.5">
+          <span className="text-body-s font-semibold text-coolgray-90">버전</span>
+          <input value={form.version || '자동 채번'} disabled className={INPUT_CLASS} />
+        </label>
+
+        <label className="flex flex-col gap-1.5">
+          <span className="text-body-s font-semibold text-coolgray-90">적용 시작년도</span>
+          <input
+            value={form.yearStart}
+            disabled={isSaving}
+            inputMode="numeric"
+            placeholder="2023"
+            onChange={(event) => onChange('yearStart', event.target.value)}
+            className={INPUT_CLASS}
+          />
+        </label>
+
+        <label className="flex flex-col gap-1.5">
+          <span className="text-body-s font-semibold text-coolgray-90">적용 종료년도</span>
+          <input
+            value={form.yearEnd}
+            disabled={isSaving}
+            inputMode="numeric"
+            placeholder="2023"
+            onChange={(event) => onChange('yearEnd', event.target.value)}
+            className={INPUT_CLASS}
+          />
+        </label>
+
+        <label className="flex items-end gap-2 pb-2">
+          <input
+            type="checkbox"
+            checked={form.active}
+            disabled={isSaving}
+            onChange={(event) => onChange('active', event.target.checked)}
+            className="h-4 w-4 accent-primary-60"
+          />
+          <span className="text-body-s font-semibold text-coolgray-90">활성 세트</span>
+        </label>
+
+        <label className="flex flex-col gap-1.5 lg:col-span-2">
+          <span className="text-body-s font-semibold text-coolgray-90">설명</span>
+          <input
+            value={form.description}
+            disabled={isSaving}
+            placeholder="컴퓨터·AI학부 23학번 일반과정 졸업요건"
+            onChange={(event) => onChange('description', event.target.value)}
+            className={INPUT_CLASS}
+          />
+        </label>
+
+        <label className="flex flex-col gap-1.5">
+          <span className="text-body-s font-semibold text-coolgray-90">시트 이미지 URL</span>
+          <input
+            value={form.sheetImageUrl}
+            disabled={isSaving}
+            placeholder="비워두면 시트 이미지 없음"
+            onChange={(event) => onChange('sheetImageUrl', event.target.value)}
+            className={INPUT_CLASS}
+          />
+        </label>
+      </div>
+    </section>
+  );
+}

--- a/src/constants/querykeys/queryKeys.ts
+++ b/src/constants/querykeys/queryKeys.ts
@@ -10,4 +10,13 @@ export const QUERY_KEYS = {
   // 관리자 과목 분류 조회를 필터별로 캐시하고, 저장 후에는 이 접두사로 한 번에 무효화한다.
   ADMIN_COURSE_CLASSIFICATIONS_ROOT: ['admin', 'course-classifications'] as const,
   GET_ADMIN_COURSE_CLASSIFICATIONS: (filters: object) => ['admin', 'course-classifications', filters] as const,
+  GET_ADMIN_RULE_TYPES: ['admin', 'rule-types'] as const,
+  GET_ADMIN_COLLEGES: ['admin', 'colleges'] as const,
+  ADMIN_DEPARTMENTS_ROOT: ['admin', 'departments'] as const,
+  GET_ADMIN_DEPARTMENTS: (collegeId?: number) => ['admin', 'departments', { collegeId }] as const,
+  ADMIN_GRADUATION_RULES_ROOT: ['admin', 'graduation-rules'] as const,
+  GET_ADMIN_GRADUATION_RULES: (filters: object) => ['admin', 'graduation-rules', filters] as const,
+  ADMIN_REQUIREMENT_SETS_ROOT: ['admin', 'requirement-sets'] as const,
+  GET_ADMIN_REQUIREMENT_SETS: (filters: object) => ['admin', 'requirement-sets', filters] as const,
+  GET_ADMIN_REQUIREMENT_SET_DETAIL: (id: number) => ['admin', 'requirement-sets', id] as const,
 } as const;

--- a/src/hooks/admin/useAdminColleges.ts
+++ b/src/hooks/admin/useAdminColleges.ts
@@ -1,0 +1,8 @@
+import { getAdminColleges } from '@/apis/admin/graduationRequirement';
+import { QUERY_KEYS } from '@/constants/querykeys/queryKeys';
+import { useCoreQuery } from '@/hooks/customQuery';
+
+// 졸업 요건 세트 필터/등록 폼의 단과대 드롭다운 선택지 조회.
+export default function useAdminColleges() {
+  return useCoreQuery(QUERY_KEYS.GET_ADMIN_COLLEGES, getAdminColleges);
+}

--- a/src/hooks/admin/useAdminDepartments.ts
+++ b/src/hooks/admin/useAdminDepartments.ts
@@ -1,0 +1,8 @@
+import { getAdminDepartments } from '@/apis/admin/graduationRequirement';
+import { QUERY_KEYS } from '@/constants/querykeys/queryKeys';
+import { useCoreQuery } from '@/hooks/customQuery';
+
+// 단과대 선택 시 해당 단과대의 학과만, 미선택 시 전체 학과를 조회한다.
+export default function useAdminDepartments(collegeId?: number) {
+  return useCoreQuery(QUERY_KEYS.GET_ADMIN_DEPARTMENTS(collegeId), () => getAdminDepartments(collegeId));
+}

--- a/src/hooks/admin/useAdminGraduationRules.ts
+++ b/src/hooks/admin/useAdminGraduationRules.ts
@@ -1,0 +1,9 @@
+import { getAdminGraduationRules } from '@/apis/admin/graduationRequirement';
+import { QUERY_KEYS } from '@/constants/querykeys/queryKeys';
+import { useCoreQuery } from '@/hooks/customQuery';
+import type { TGraduationRuleFilters } from '@/types/admin/TGetGraduationRules';
+
+// 관리자 졸업 규칙 목록 조회. 필터 객체를 query key에 포함해 필터별 캐시를 분리한다.
+export default function useAdminGraduationRules(filters: TGraduationRuleFilters) {
+  return useCoreQuery(QUERY_KEYS.GET_ADMIN_GRADUATION_RULES(filters), () => getAdminGraduationRules(filters));
+}

--- a/src/hooks/admin/useAdminRequirementSetDetail.ts
+++ b/src/hooks/admin/useAdminRequirementSetDetail.ts
@@ -1,0 +1,14 @@
+import { getAdminRequirementSetDetail } from '@/apis/admin/graduationRequirement';
+import { QUERY_KEYS } from '@/constants/querykeys/queryKeys';
+import { useCoreQuery } from '@/hooks/customQuery';
+
+// 선택한 졸업 요건 세트의 연결 규칙 ID를 조회한다. id가 없으면 호출하지 않는다.
+export default function useAdminRequirementSetDetail(id: number | null) {
+  return useCoreQuery(
+    QUERY_KEYS.GET_ADMIN_REQUIREMENT_SET_DETAIL(id ?? 0),
+    () => getAdminRequirementSetDetail(id ?? 0),
+    {
+      enabled: id !== null,
+    },
+  );
+}

--- a/src/hooks/admin/useAdminRequirementSets.ts
+++ b/src/hooks/admin/useAdminRequirementSets.ts
@@ -1,0 +1,9 @@
+import { getAdminRequirementSets } from '@/apis/admin/graduationRequirement';
+import { QUERY_KEYS } from '@/constants/querykeys/queryKeys';
+import { useCoreQuery } from '@/hooks/customQuery';
+import type { TRequirementSetFilters } from '@/types/admin/TRequirementSets';
+
+// 졸업 요건 세트 목록 조회 훅. departmentId/year 필터별로 캐시를 분리한다.
+export default function useAdminRequirementSets(filters: TRequirementSetFilters) {
+  return useCoreQuery(QUERY_KEYS.GET_ADMIN_REQUIREMENT_SETS(filters), () => getAdminRequirementSets(filters));
+}

--- a/src/hooks/admin/useAdminRuleTypes.ts
+++ b/src/hooks/admin/useAdminRuleTypes.ts
@@ -1,0 +1,8 @@
+import { getAdminRuleTypes } from '@/apis/admin/graduationRequirement';
+import { QUERY_KEYS } from '@/constants/querykeys/queryKeys';
+import { useCoreQuery } from '@/hooks/customQuery';
+
+// 졸업 규칙 종류 조회 훅. 규칙별 폼 분기와 필터 선택지로 사용한다.
+export default function useAdminRuleTypes() {
+  return useCoreQuery(QUERY_KEYS.GET_ADMIN_RULE_TYPES, () => getAdminRuleTypes());
+}

--- a/src/hooks/admin/useGraduationRuleEditor.tsx
+++ b/src/hooks/admin/useGraduationRuleEditor.tsx
@@ -1,0 +1,390 @@
+import { useRef, useState } from 'react';
+import { toast } from 'sonner';
+
+import type {
+  TGraduationRuleDraft,
+  TGraduationRuleDraftField,
+  TGraduationRuleDraftValue,
+} from '@/components/admin/graduationRuleForm';
+import useAdminAreaTypes from '@/hooks/admin/useAdminAreaTypes';
+import useAdminGraduationRules from '@/hooks/admin/useAdminGraduationRules';
+import useAdminRuleTypes from '@/hooks/admin/useAdminRuleTypes';
+import useUpsertGraduationRules from '@/hooks/admin/useUpsertGraduationRules';
+import {
+  EMPTY_RULE_DRAFT,
+  nullableList,
+  optionalText,
+  parseRequiredCourseSets,
+  splitList,
+  toggleCourseType,
+  toggleNumber,
+  toNumber,
+  toPositiveInteger,
+  toRuleDraft,
+} from '@/pages/admin/graduationRequirements.helpers';
+import { useModalStore } from '@/stores/modalStore';
+import type { TGraduationRuleConfig, TGraduationRuleFilters } from '@/types/admin/TGetGraduationRules';
+import type { TAdminRuleType } from '@/types/admin/TGetRuleTypes';
+import type { TGraduationRuleUpsertItem } from '@/types/admin/TPutGraduationRules';
+import type { TCourseType } from '@/types/course';
+
+// 규칙 종류(typeName)별로 폼 입력값을 검증해 API용 ruleConfig를 조립한다. 누락 시 toast 후 null.
+const buildRuleConfig = (
+  draft: TGraduationRuleDraft,
+  ruleType: TAdminRuleType,
+  rowLabel: string,
+): TGraduationRuleConfig | null => {
+  if (ruleType.typeName === 'TOTAL_CREDITS') {
+    const minCredits = toPositiveInteger(draft.minCredits);
+    if (!minCredits) {
+      toast.error(`${rowLabel}의 최소 취득학점을 입력해주세요.`);
+      return null;
+    }
+    return { minCredits };
+  }
+
+  if (ruleType.typeName === 'GPA') {
+    const minGpa = toNumber(draft.minGpa);
+    if (minGpa === null || minGpa <= 0) {
+      toast.error(`${rowLabel}의 최소 평점평균을 입력해주세요.`);
+      return null;
+    }
+    return { minGpa };
+  }
+
+  if (ruleType.typeName === 'MIN_AREA_CREDITS') {
+    const minCredits = toPositiveInteger(draft.minCredits);
+    if (!draft.courseType) {
+      toast.error(`${rowLabel}의 이수구분을 선택해주세요.`);
+      return null;
+    }
+    if (!minCredits) {
+      toast.error(`${rowLabel}의 최소 학점을 입력해주세요.`);
+      return null;
+    }
+    return {
+      courseType: draft.courseType,
+      areaNames: draft.areaNames.length > 0 ? draft.areaNames : null,
+      minCredits,
+    };
+  }
+
+  if (ruleType.typeName === 'REQUIRED_COURSE') {
+    const courseCodes = splitList(draft.courseCodes);
+    if (courseCodes.length === 0) {
+      toast.error(`${rowLabel}의 필수 과목코드를 입력해주세요.`);
+      return null;
+    }
+    return {
+      courseCodes,
+      exemptEnglishLevels: nullableList(draft.exemptEnglishLevels),
+      requiredEnglishLevels: nullableList(draft.requiredEnglishLevels),
+    };
+  }
+
+  if (ruleType.typeName === 'ENGLISH_COURSE') {
+    const minCount = toPositiveInteger(draft.minCount);
+    if (!minCount) {
+      toast.error(`${rowLabel}의 최소 이수 개수를 입력해주세요.`);
+      return null;
+    }
+    return {
+      courseTypes: draft.courseTypes.length > 0 ? draft.courseTypes : null,
+      minCount,
+    };
+  }
+
+  if (ruleType.typeName === 'PREREQUISITE') {
+    const targetCourseCodes = splitList(draft.targetCourseCodes);
+    const prerequisiteCourseCodes = splitList(draft.prerequisiteCourseCodes);
+    if (targetCourseCodes.length === 0 || prerequisiteCourseCodes.length === 0) {
+      toast.error(`${rowLabel}의 대상/선이수 과목코드를 입력해주세요.`);
+      return null;
+    }
+    if (draft.conditionField && !draft.conditionValue.trim()) {
+      toast.error(`${rowLabel}의 조건 값을 입력해주세요.`);
+      return null;
+    }
+    return {
+      targetCourseCodes,
+      prerequisiteCourseCodes,
+      conditionField: draft.conditionField || null,
+      conditionValue: draft.conditionField ? draft.conditionValue.trim() : null,
+    };
+  }
+
+  if (ruleType.typeName === 'SCIENCE_EXPERIMENT') {
+    const minCount = toPositiveInteger(draft.minCount);
+    if (!minCount) {
+      toast.error(`${rowLabel}의 최소 이수 개수를 입력해주세요.`);
+      return null;
+    }
+    return { minCount };
+  }
+
+  if (ruleType.typeName === 'SCIENCE_CONFLICT') {
+    return {};
+  }
+
+  const requiredCourseSets = parseRequiredCourseSets(draft.requiredCourseSetsText);
+  if (requiredCourseSets.length === 0) {
+    toast.error(`${rowLabel}의 필수 과목 세트를 입력해주세요.`);
+    return null;
+  }
+  return {
+    exemptStudentTypes: splitList(draft.exemptStudentTypes),
+    requiredCourseSets,
+  };
+};
+
+// 폼 draft 한 건을 업서트 요청 항목으로 변환한다. 검증 실패 시 toast 후 null.
+const buildRuleUpsertItem = (
+  draft: TGraduationRuleDraft,
+  index: number,
+  ruleTypes: TAdminRuleType[],
+): TGraduationRuleUpsertItem | null => {
+  const rowLabel = `${index + 1}번째 규칙`;
+  const ruleTypeId = toPositiveInteger(draft.ruleTypeId);
+  const ruleType = ruleTypeId ? ruleTypes.find((type) => type.id === ruleTypeId) : null;
+  const ruleName = draft.ruleName.trim();
+
+  if (!ruleTypeId || !ruleType) {
+    toast.error(`${rowLabel}의 규칙 종류를 선택해주세요.`);
+    return null;
+  }
+  if (!ruleName) {
+    toast.error(`${rowLabel}의 규칙명을 입력해주세요.`);
+    return null;
+  }
+
+  const ruleConfig = buildRuleConfig(draft, ruleType, rowLabel);
+  if (!ruleConfig) return null;
+
+  return {
+    id: draft.id,
+    ruleTypeId,
+    ruleName,
+    ruleConfig,
+    description: optionalText(draft.description),
+  };
+};
+
+// 졸업 규칙 탭의 상태·쿼리·검증·저장 로직을 모은 컨트롤러 훅.
+// rules 쿼리는 하단 공유 테이블도 사용하므로 여기서 소유하고 결과를 그대로 반환한다.
+export default function useGraduationRuleEditor() {
+  const ruleDraftIndex = useRef(0);
+  const openConfirm = useModalStore((state) => state.openConfirm);
+
+  const [selectedRuleTypeIds, setSelectedRuleTypeIds] = useState<number[]>([]);
+  const [selectedCourseTypes, setSelectedCourseTypes] = useState<TCourseType[]>([]);
+  const [appliedFilters, setAppliedFilters] = useState<TGraduationRuleFilters>({});
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [drafts, setDrafts] = useState<TGraduationRuleDraft[]>([]);
+
+  const { data: areaTypes = [] } = useAdminAreaTypes();
+  const { data: ruleTypes = [], isError: isRuleTypeError } = useAdminRuleTypes();
+  const {
+    data: rules = [],
+    isPending: isRulesLoading,
+    isError: isRulesError,
+    refetch: refetchRules,
+  } = useAdminGraduationRules(appliedFilters);
+  const { mutate: upsertGraduationRules, isPending: isSaving } = useUpsertGraduationRules();
+
+  const clearDrafts = () => {
+    setSelectedIds(new Set());
+    setDrafts([]);
+  };
+
+  const onRuleTypeToggle = (ruleTypeId: number) => {
+    setSelectedRuleTypeIds((prev) => toggleNumber(prev, ruleTypeId));
+  };
+
+  const onCourseTypeToggle = (courseType: TCourseType) => {
+    setSelectedCourseTypes((prev) => toggleCourseType(prev, courseType));
+  };
+
+  const applyFilters = () => {
+    clearDrafts();
+    setAppliedFilters({
+      ...(selectedRuleTypeIds.length > 0 ? { ruleTypeIds: selectedRuleTypeIds } : {}),
+      ...(selectedCourseTypes.length > 0 ? { courseTypes: selectedCourseTypes } : {}),
+    });
+  };
+
+  const resetFilters = () => {
+    setSelectedRuleTypeIds([]);
+    setSelectedCourseTypes([]);
+    setAppliedFilters({});
+    clearDrafts();
+  };
+
+  const addDraft = () => {
+    const clientId = `new-rule-${ruleDraftIndex.current++}`;
+    setDrafts((prev) => [...prev, { ...EMPTY_RULE_DRAFT, clientId }]);
+  };
+
+  const removeDraft = (clientId: string) => {
+    const removedDraft = drafts.find((draft) => draft.clientId === clientId);
+    if (removedDraft?.id !== null && removedDraft?.id !== undefined) {
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+        next.delete(removedDraft.id as number);
+        return next;
+      });
+    }
+    setDrafts((prev) => prev.filter((draft) => draft.clientId !== clientId));
+  };
+
+  const changeDraft = (clientId: string, field: TGraduationRuleDraftField, value: TGraduationRuleDraftValue) => {
+    setDrafts((prev) =>
+      prev.map((draft) => {
+        if (draft.clientId !== clientId) return draft;
+        const next = { ...draft, [field]: value };
+        // 규칙 종류를 바꾸면 종류별 설정값이 의미를 잃으므로 모두 초기화한다.
+        if (field === 'ruleTypeId') {
+          return {
+            ...next,
+            minCredits: '',
+            minGpa: '',
+            minCount: '',
+            courseType: '',
+            areaNames: [],
+            courseCodes: '',
+            exemptEnglishLevels: '',
+            requiredEnglishLevels: '',
+            courseTypes: [],
+            targetCourseCodes: '',
+            prerequisiteCourseCodes: '',
+            conditionField: '',
+            conditionValue: '',
+            exemptStudentTypes: '',
+            requiredCourseSetsText: '',
+          };
+        }
+        return next;
+      }),
+    );
+  };
+
+  // 하단 공유 테이블에서 "전체 선택"을 눌렀을 때(규칙 편집 모드) 현재 목록을 draft로 시딩한다.
+  const selectRows = (checked: boolean) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      rules.forEach((rule) => {
+        if (checked) {
+          next.add(rule.id);
+        } else {
+          next.delete(rule.id);
+        }
+      });
+      return next;
+    });
+    setDrafts((prev) => {
+      const newDrafts = prev.filter((draft) => draft.id === null);
+      if (!checked) return newDrafts;
+      const existingDraftIds = new Set(prev.filter((draft) => draft.id !== null).map((draft) => draft.id));
+      const visibleDrafts = rules.filter((rule) => !existingDraftIds.has(rule.id)).map((rule) => toRuleDraft(rule));
+      return [...prev, ...visibleDrafts];
+    });
+  };
+
+  // 하단 공유 테이블에서 행 하나를 토글했을 때(규칙 편집 모드) draft를 추가/제거한다.
+  const selectRow = (ruleId: number, checked: boolean) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (checked) {
+        next.add(ruleId);
+      } else {
+        next.delete(ruleId);
+      }
+      return next;
+    });
+    setDrafts((prev) => {
+      if (!checked) return prev.filter((draft) => draft.id !== ruleId);
+      const selectedRule = rules.find((rule) => rule.id === ruleId);
+      if (!selectedRule || prev.some((draft) => draft.id === ruleId)) return prev;
+      return [...prev, toRuleDraft(selectedRule)];
+    });
+  };
+
+  const submit = () => {
+    if (drafts.length === 0) {
+      toast.error('수정하거나 추가할 졸업 규칙을 먼저 선택해주세요.');
+      return;
+    }
+
+    const items: TGraduationRuleUpsertItem[] = [];
+    for (const [index, draft] of drafts.entries()) {
+      const item = buildRuleUpsertItem(draft, index, ruleTypes);
+      if (!item) return;
+      items.push(item);
+    }
+
+    const createCount = items.filter((item) => item.id === null).length;
+    const updateCount = items.length - createCount;
+    const summaries = items.map((item, index) => ({
+      clientId: drafts[index]?.clientId ?? item.ruleName,
+      item,
+    }));
+
+    openConfirm({
+      title: '졸업 규칙 수정',
+      action: `총 ${items.length}건 저장 (수정 ${updateCount}건, 신규 ${createCount}건)`,
+      description: '규칙 설정값은 졸업 판정에 바로 사용됩니다. 저장 전 내용을 확인해주세요.',
+      confirmText: '수정하기',
+      cancelText: '취소하기',
+      details: (
+        <div className="flex max-h-52 flex-col gap-2 overflow-y-auto text-body-s">
+          {summaries.map(({ clientId, item }) => {
+            const ruleType = ruleTypes.find((type) => type.id === item.ruleTypeId);
+            return (
+              <div key={clientId} className="rounded-lg bg-white px-4 py-3">
+                <p className="font-semibold text-coolgray-90">
+                  {item.id === null ? '신규' : `ID ${item.id}`} · {item.ruleName}
+                </p>
+                <p className="mt-1 text-coolgray-60">{ruleType?.typeName ?? item.ruleTypeId}</p>
+              </div>
+            );
+          })}
+        </div>
+      ),
+      onConfirm: () => {
+        upsertGraduationRules(
+          { items },
+          {
+            onSuccess: () => {
+              toast.success('졸업 규칙을 수정했어요.');
+              clearDrafts();
+              refetchRules();
+            },
+          },
+        );
+      },
+    });
+  };
+
+  return {
+    areaTypes,
+    ruleTypes,
+    isRuleTypeError,
+    rules,
+    isRulesLoading,
+    isRulesError,
+    selectedRuleTypeIds,
+    selectedCourseTypes,
+    onRuleTypeToggle,
+    onCourseTypeToggle,
+    applyFilters,
+    resetFilters,
+    drafts,
+    selectedIds,
+    addDraft,
+    removeDraft,
+    changeDraft,
+    submit,
+    isSaving,
+    selectRows,
+    selectRow,
+  };
+}

--- a/src/hooks/admin/useGraduationRuleEditor.tsx
+++ b/src/hooks/admin/useGraduationRuleEditor.tsx
@@ -126,15 +126,20 @@ const buildRuleConfig = (
     return {};
   }
 
-  const requiredCourseSets = parseRequiredCourseSets(draft.requiredCourseSetsText);
-  if (requiredCourseSets.length === 0) {
-    toast.error(`${rowLabel}의 필수 과목 세트를 입력해주세요.`);
-    return null;
+  if (ruleType.typeName === 'THESIS') {
+    const requiredCourseSets = parseRequiredCourseSets(draft.requiredCourseSetsText);
+    if (requiredCourseSets.length === 0) {
+      toast.error(`${rowLabel}의 필수 과목 세트를 입력해주세요.`);
+      return null;
+    }
+    return {
+      exemptStudentTypes: splitList(draft.exemptStudentTypes),
+      requiredCourseSets,
+    };
   }
-  return {
-    exemptStudentTypes: splitList(draft.exemptStudentTypes),
-    requiredCourseSets,
-  };
+
+  // 알 수 없는 규칙 종류는 검증할 수 없으므로 방어적으로 null을 반환한다.
+  return null;
 };
 
 // 폼 draft 한 건을 업서트 요청 항목으로 변환한다. 검증 실패 시 toast 후 null.

--- a/src/hooks/admin/useRequirementSetEditor.tsx
+++ b/src/hooks/admin/useRequirementSetEditor.tsx
@@ -1,0 +1,290 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+import { getAdminDepartments, getAdminRequirementSetDetail } from '@/apis/admin/graduationRequirement';
+import type { TRequirementSetFormState } from '@/components/admin/requirementSetForm';
+import { QUERY_KEYS } from '@/constants/querykeys/queryKeys';
+import useAdminColleges from '@/hooks/admin/useAdminColleges';
+import useAdminDepartments from '@/hooks/admin/useAdminDepartments';
+import useAdminRequirementSets from '@/hooks/admin/useAdminRequirementSets';
+import useSaveRequirementSet from '@/hooks/admin/useSaveRequirementSet';
+import { optionalText, toPositiveInteger, toRequirementSetForm } from '@/pages/admin/graduationRequirements.helpers';
+import { useModalStore } from '@/stores/modalStore';
+import type { TAdminGraduationRule } from '@/types/admin/TGetGraduationRules';
+import type {
+  TRequirementSetCreateRequest,
+  TRequirementSetFilters,
+  TRequirementSetUpdateRequest,
+} from '@/types/admin/TRequirementSets';
+
+const EMPTY_SET_FORM: TRequirementSetFormState = {
+  id: null,
+  departmentId: null,
+  collegeName: '',
+  departmentName: '',
+  yearStart: '',
+  yearEnd: '',
+  version: '',
+  description: '',
+  sheetImageUrl: '',
+  active: true,
+};
+
+// 신규 생성(POST)과 수정(PUT)은 요청 본문이 다르므로 id 유무로 구분한다.
+type TRequirementSetSavePayload =
+  | {
+      id: null;
+      body: TRequirementSetCreateRequest;
+    }
+  | {
+      id: number;
+      body: TRequirementSetUpdateRequest;
+    };
+
+// 졸업 세트 탭의 상태·쿼리·검증·저장 로직을 모은 컨트롤러 훅.
+// 세트에 포함할 규칙 선택(setRuleIds)은 하단 공유 테이블에서 토글하므로 그 핸들러도 함께 노출한다.
+export default function useRequirementSetEditor() {
+  const queryClient = useQueryClient();
+  const openConfirm = useModalStore((state) => state.openConfirm);
+
+  const [filterCollegeId, setFilterCollegeId] = useState('');
+  const [filterDepartmentId, setFilterDepartmentId] = useState('');
+  const [filterYear, setFilterYear] = useState('');
+  const [appliedFilters, setAppliedFilters] = useState<TRequirementSetFilters>({});
+  const [form, setForm] = useState<TRequirementSetFormState>(EMPTY_SET_FORM);
+  const [ruleIds, setRuleIds] = useState<Set<number>>(new Set());
+  const [isLoadingDetail, setIsLoadingDetail] = useState(false);
+
+  const { data: colleges = [] } = useAdminColleges();
+  const { data: departments = [] } = useAdminDepartments();
+  const selectedFilterCollegeId = filterCollegeId ? toPositiveInteger(filterCollegeId) : null;
+  const { data: filterDepartments = [], isPending: isFilterDepartmentsLoading } = useAdminDepartments(
+    selectedFilterCollegeId ?? undefined,
+  );
+  // 폼에서 입력한 단과대명으로 학과 선택지를 좁힌다. (단과대명 → id 매칭)
+  const selectedFormCollegeId = colleges.find((college) => college.collegeName === form.collegeName.trim())?.id;
+  const { data: formDepartments = [] } = useAdminDepartments(selectedFormCollegeId);
+  const { data: requirementSets = [] } = useAdminRequirementSets(appliedFilters);
+  const { mutate: saveRequirementSet, isPending: isSaving } = useSaveRequirementSet();
+
+  const applyFilters = () => {
+    const collegeId = filterCollegeId.trim() ? toPositiveInteger(filterCollegeId) : null;
+    const departmentId = filterDepartmentId.trim() ? toPositiveInteger(filterDepartmentId) : null;
+    const year = filterYear.trim() ? toPositiveInteger(filterYear) : null;
+    setAppliedFilters({
+      ...(collegeId ? { collegeId } : {}),
+      ...(departmentId ? { departmentId } : {}),
+      ...(year ? { year } : {}),
+    });
+  };
+
+  const resetFilters = () => {
+    setFilterCollegeId('');
+    setFilterDepartmentId('');
+    setFilterYear('');
+    setAppliedFilters({});
+  };
+
+  // 단과대를 바꾸면 학과 선택은 초기화한다. (단과대-학과 종속 관계)
+  const onCollegeChange = (value: string) => {
+    setFilterCollegeId(value);
+    setFilterDepartmentId('');
+  };
+
+  const newSet = () => {
+    setForm(EMPTY_SET_FORM);
+    setRuleIds(new Set());
+  };
+
+  const loadSet = async (setId: number) => {
+    setIsLoadingDetail(true);
+    try {
+      const detail = await queryClient.fetchQuery({
+        queryKey: QUERY_KEYS.GET_ADMIN_REQUIREMENT_SET_DETAIL(setId),
+        queryFn: () => getAdminRequirementSetDetail(setId),
+      });
+      let department = departments.find((item) => item.id === detail.departmentId);
+      // 단과대 필터로 좁혀진 departments에 없으면 전체 학과를 다시 조회해 매칭한다.
+      if (!department) {
+        const allDepartments = await queryClient.fetchQuery({
+          queryKey: QUERY_KEYS.GET_ADMIN_DEPARTMENTS(),
+          queryFn: () => getAdminDepartments(),
+        });
+        department = allDepartments.find((item) => item.id === detail.departmentId);
+      }
+      setForm(toRequirementSetForm(detail, department));
+      setRuleIds(new Set(detail.graduationRuleIds));
+    } catch {
+      toast.error('졸업 요건 세트를 불러오지 못했어요.');
+    } finally {
+      setIsLoadingDetail(false);
+    }
+  };
+
+  const changeForm = (field: keyof TRequirementSetFormState, value: string | boolean | number | null) => {
+    setForm((prev) => {
+      if (field === 'collegeName') {
+        return { ...prev, collegeName: String(value), departmentId: null, departmentName: '' };
+      }
+      if (field === 'departmentName') {
+        const departmentName = String(value);
+        const matchedDepartment =
+          formDepartments.find((department) => department.departmentName === departmentName) ??
+          departments.find((department) => department.departmentName === departmentName);
+        return {
+          ...prev,
+          departmentId: matchedDepartment?.id ?? null,
+          departmentName,
+          collegeName: prev.collegeName || matchedDepartment?.collegeName || '',
+        };
+      }
+      return { ...prev, [field]: value };
+    });
+  };
+
+  const buildRequest = (): TRequirementSetSavePayload | null => {
+    const collegeName = form.collegeName.trim();
+    const departmentName = form.departmentName.trim();
+    const yearStart = toPositiveInteger(form.yearStart);
+    const yearEnd = toPositiveInteger(form.yearEnd);
+
+    if (form.id === null && !collegeName) {
+      toast.error('단과대를 입력해주세요.');
+      return null;
+    }
+    if (form.id === null && !departmentName) {
+      toast.error('학과를 입력해주세요.');
+      return null;
+    }
+    if (!yearStart || !yearEnd) {
+      toast.error('적용 시작/종료년도를 입력해주세요.');
+      return null;
+    }
+    if (yearStart > yearEnd) {
+      toast.error('적용 시작년도는 종료년도보다 클 수 없습니다.');
+      return null;
+    }
+    if (ruleIds.size === 0) {
+      toast.error('세트에 포함할 졸업 규칙을 선택해주세요.');
+      return null;
+    }
+
+    const baseBody = {
+      yearStart,
+      yearEnd,
+      description: optionalText(form.description),
+      sheetImageUrl: optionalText(form.sheetImageUrl),
+      active: form.active,
+      graduationRuleIds: Array.from(ruleIds),
+    };
+
+    if (form.id === null) {
+      return {
+        id: null,
+        body: {
+          collegeName,
+          departmentName,
+          ...baseBody,
+        },
+      };
+    }
+
+    return {
+      id: form.id,
+      body: baseBody,
+    };
+  };
+
+  const submit = () => {
+    const payload = buildRequest();
+    if (!payload) return;
+
+    openConfirm({
+      title: '졸업 요건 세트 저장',
+      action: `${payload.id === null ? '신규 세트 생성' : `세트 ID ${payload.id} 수정`} · 규칙 ${payload.body.graduationRuleIds.length}건 연결`,
+      description: '세트는 학과와 입학년도에 적용되는 졸업 판정 기준입니다. 저장 전 내용을 확인해주세요.',
+      confirmText: '저장하기',
+      cancelText: '취소하기',
+      details: (
+        <dl className="grid grid-cols-[120px_1fr] gap-x-4 gap-y-2 text-body-s">
+          <dt className="text-coolgray-60">단과대</dt>
+          <dd className="font-semibold text-coolgray-90">{form.collegeName || '기존 값 유지'}</dd>
+          <dt className="text-coolgray-60">학과</dt>
+          <dd className="font-semibold text-coolgray-90">{form.departmentName || '기존 값 유지'}</dd>
+          <dt className="text-coolgray-60">적용년도</dt>
+          <dd className="text-coolgray-90">
+            {payload.body.yearStart} - {payload.body.yearEnd}
+          </dd>
+          <dt className="text-coolgray-60">버전</dt>
+          <dd className="text-coolgray-90">{payload.id === null ? '자동 채번' : '서버 관리'}</dd>
+          <dt className="text-coolgray-60">활성</dt>
+          <dd className="text-coolgray-90">{payload.body.active ? '활성' : '비활성'}</dd>
+        </dl>
+      ),
+      onConfirm: () => {
+        saveRequirementSet(payload, {
+          onSuccess: () => {
+            toast.success('졸업 요건 세트를 저장했어요.');
+            newSet();
+          },
+        });
+      },
+    });
+  };
+
+  // 하단 공유 테이블 행 토글(세트 모드): 세트에 포함할 규칙 id를 추가/제거한다.
+  const toggleRule = (ruleId: number, checked: boolean) => {
+    setRuleIds((prev) => {
+      const next = new Set(prev);
+      if (checked) {
+        next.add(ruleId);
+      } else {
+        next.delete(ruleId);
+      }
+      return next;
+    });
+  };
+
+  // 하단 공유 테이블 전체 토글(세트 모드): 현재 목록의 규칙들을 일괄 포함/제외한다.
+  const toggleAllRules = (rules: TAdminGraduationRule[], checked: boolean) => {
+    setRuleIds((prev) => {
+      const next = new Set(prev);
+      rules.forEach((rule) => {
+        if (checked) {
+          next.add(rule.id);
+        } else {
+          next.delete(rule.id);
+        }
+      });
+      return next;
+    });
+  };
+
+  return {
+    colleges,
+    departments,
+    filterDepartments,
+    formDepartments,
+    isFilterDepartmentsLoading,
+    requirementSets,
+    filterCollegeId,
+    filterDepartmentId,
+    filterYear,
+    onCollegeChange,
+    onDepartmentChange: setFilterDepartmentId,
+    onYearChange: setFilterYear,
+    applyFilters,
+    resetFilters,
+    form,
+    ruleIds,
+    isLoadingDetail,
+    changeForm,
+    newSet,
+    loadSet,
+    submit,
+    isSaving,
+    toggleRule,
+    toggleAllRules,
+  };
+}

--- a/src/hooks/admin/useRequirementSetEditor.tsx
+++ b/src/hooks/admin/useRequirementSetEditor.tsx
@@ -125,10 +125,12 @@ export default function useRequirementSetEditor() {
   const changeForm = (field: keyof TRequirementSetFormState, value: string | boolean | number | null) => {
     setForm((prev) => {
       if (field === 'collegeName') {
-        return { ...prev, collegeName: String(value), departmentId: null, departmentName: '' };
+        // value가 string이 아닐 때 'null'/'undefined' 문자열로 저장되지 않도록 방어한다.
+        const collegeName = typeof value === 'string' ? value : '';
+        return { ...prev, collegeName, departmentId: null, departmentName: '' };
       }
       if (field === 'departmentName') {
-        const departmentName = String(value);
+        const departmentName = typeof value === 'string' ? value : '';
         const matchedDepartment =
           formDepartments.find((department) => department.departmentName === departmentName) ??
           departments.find((department) => department.departmentName === departmentName);

--- a/src/hooks/admin/useSaveRequirementSet.ts
+++ b/src/hooks/admin/useSaveRequirementSet.ts
@@ -1,0 +1,41 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+import { postAdminRequirementSet, putAdminRequirementSet } from '@/apis/admin/graduationRequirement';
+import { QUERY_KEYS } from '@/constants/querykeys/queryKeys';
+import { useCoreMutation } from '@/hooks/customQuery';
+import type { TRequirementSetCreateRequest, TRequirementSetUpdateRequest } from '@/types/admin/TRequirementSets';
+import { getErrorCode, getErrorMessage } from '@/utils/error';
+
+type TSaveRequirementSetVariables =
+  | {
+      id: null;
+      body: TRequirementSetCreateRequest;
+    }
+  | {
+      id: number;
+      body: TRequirementSetUpdateRequest;
+    };
+
+// 졸업 요건 세트 생성/수정 저장 훅. id가 있으면 수정, 없으면 생성한다.
+export default function useSaveRequirementSet() {
+  const queryClient = useQueryClient();
+
+  return useCoreMutation<number | null, TSaveRequirementSetVariables>(
+    ({ id, body }) => (id === null ? postAdminRequirementSet(body) : putAdminRequirementSet(id, body)),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: QUERY_KEYS.ADMIN_REQUIREMENT_SETS_ROOT });
+        queryClient.invalidateQueries({ queryKey: QUERY_KEYS.GET_ADMIN_COLLEGES });
+        queryClient.invalidateQueries({ queryKey: QUERY_KEYS.ADMIN_DEPARTMENTS_ROOT });
+      },
+      onError: (error) => {
+        if (getErrorCode(error) === 'CURRICULUM409_3') {
+          toast.error('적용년도가 겹치는 기존 활성 세트를 먼저 비활성화해주세요.');
+          return;
+        }
+        toast.error(getErrorMessage(error) ?? '졸업 요건 세트 저장 중 오류가 발생했습니다.');
+      },
+    },
+  );
+}

--- a/src/hooks/admin/useUpsertGraduationRules.ts
+++ b/src/hooks/admin/useUpsertGraduationRules.ts
@@ -1,0 +1,18 @@
+import { useQueryClient } from '@tanstack/react-query';
+
+import { putAdminGraduationRules } from '@/apis/admin/graduationRequirement';
+import { QUERY_KEYS } from '@/constants/querykeys/queryKeys';
+import { useCoreMutation } from '@/hooks/customQuery';
+import type { TGraduationRuleUpsertRequest } from '@/types/admin/TPutGraduationRules';
+
+// 졸업 규칙 등록/수정 통합 저장 훅. 저장 성공 후 규칙 목록과 세트 상세를 다시 보게 한다.
+export default function useUpsertGraduationRules() {
+  const queryClient = useQueryClient();
+
+  return useCoreMutation<number[], TGraduationRuleUpsertRequest>((body) => putAdminGraduationRules(body), {
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.ADMIN_GRADUATION_RULES_ROOT });
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.ADMIN_REQUIREMENT_SETS_ROOT });
+    },
+  });
+}

--- a/src/pages/admin/graduationRequirements.helpers.ts
+++ b/src/pages/admin/graduationRequirements.helpers.ts
@@ -54,8 +54,11 @@ export const toPositiveInteger = (value: string) => {
 };
 
 // 유한한 숫자만 허용한다. 그 외에는 null. (평점평균처럼 소수 허용)
+// 빈 문자열은 Number('')가 0을 반환하므로, 미입력(빈 값)과 실제 0을 구분하기 위해 먼저 걸러낸다.
 export const toNumber = (value: string) => {
-  const parsed = Number(value.trim());
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const parsed = Number(trimmed);
   if (!Number.isFinite(parsed)) return null;
   return parsed;
 };

--- a/src/pages/admin/graduationRequirements.helpers.ts
+++ b/src/pages/admin/graduationRequirements.helpers.ts
@@ -1,0 +1,175 @@
+import type { TGraduationRuleDraft } from '@/components/admin/graduationRuleForm';
+import type { TRequirementSetFormState } from '@/components/admin/requirementSetForm';
+import type { TAdminDepartment } from '@/types/admin/TGetAcademicOrganizations';
+import type { TAdminGraduationRule } from '@/types/admin/TGetGraduationRules';
+import type { TCourseType } from '@/types/course';
+
+// 신규 졸업 규칙 행의 초기값. 모든 입력값은 편의를 위해 문자열/배열로 다룬다.
+export const EMPTY_RULE_DRAFT: Omit<TGraduationRuleDraft, 'clientId'> = {
+  id: null,
+  ruleTypeId: '',
+  ruleName: '',
+  description: '',
+  minCredits: '',
+  minGpa: '',
+  minCount: '',
+  courseType: '',
+  areaNames: [],
+  courseCodes: '',
+  exemptEnglishLevels: '',
+  requiredEnglishLevels: '',
+  courseTypes: [],
+  targetCourseCodes: '',
+  prerequisiteCourseCodes: '',
+  conditionField: '',
+  conditionValue: '',
+  exemptStudentTypes: '',
+  requiredCourseSetsText: '',
+};
+
+// 공백을 제거하고, 빈 문자열이면 null로 바꾼다. (선택 입력 필드의 직렬화용)
+export const optionalText = (value: string) => {
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+};
+
+// 콤마로 구분된 문자열을 trim·빈값 제거한 배열로 변환한다.
+export const splitList = (value: string) =>
+  value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+
+// splitList 결과가 비어 있으면 null을 반환한다. (선택 목록 필드용)
+export const nullableList = (value: string) => {
+  const list = splitList(value);
+  return list.length > 0 ? list : null;
+};
+
+// 양의 정수만 허용한다. 그 외에는 null.
+export const toPositiveInteger = (value: string) => {
+  const parsed = Number(value.trim());
+  if (!Number.isInteger(parsed) || parsed <= 0) return null;
+  return parsed;
+};
+
+// 유한한 숫자만 허용한다. 그 외에는 null. (평점평균처럼 소수 허용)
+export const toNumber = (value: string) => {
+  const parsed = Number(value.trim());
+  if (!Number.isFinite(parsed)) return null;
+  return parsed;
+};
+
+// 숫자 배열에서 target을 토글한다.
+export const toggleNumber = (values: number[], target: number) => {
+  if (values.includes(target)) return values.filter((value) => value !== target);
+  return [...values, target];
+};
+
+// 이수구분 배열에서 target을 토글한다.
+export const toggleCourseType = (values: TCourseType[], target: TCourseType) => {
+  if (values.includes(target)) return values.filter((value) => value !== target);
+  return [...values, target];
+};
+
+// ruleConfig의 unknown 값에서 문자열 배열만 안전하게 추출한다.
+const readStringArray = (value: unknown) => {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === 'string');
+};
+
+// ruleConfig의 unknown 값에서 이수구분 배열만 안전하게 추출한다.
+const readCourseTypeArray = (value: unknown) => {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is TCourseType => typeof item === 'string') as TCourseType[];
+};
+
+// ruleConfig의 unknown 값을 문자열로 변환한다. (숫자도 문자열화)
+const readString = (value: unknown) => {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number') return String(value);
+  return '';
+};
+
+// requiredCourseSets(3중 배열)를 폼 textarea용 텍스트로 직렬화한다.
+// 한 줄 = 하나의 세트, '|'로 그룹 구분, 그룹 내부는 콤마 구분.
+const formatRequiredCourseSets = (value: unknown) => {
+  if (!Array.isArray(value)) return '';
+  return value
+    .map((set) => {
+      if (!Array.isArray(set)) return '';
+      return set
+        .map((group) => (Array.isArray(group) ? group.filter((code) => typeof code === 'string').join(',') : ''))
+        .filter(Boolean)
+        .join(' | ');
+    })
+    .filter(Boolean)
+    .join('\n');
+};
+
+// 폼 textarea 텍스트를 다시 requiredCourseSets(3중 배열)로 파싱한다.
+export const parseRequiredCourseSets = (value: string) =>
+  value
+    .split('\n')
+    .map((line) =>
+      line
+        .split('|')
+        .map((group) => splitList(group))
+        .filter((group) => group.length > 0),
+    )
+    .filter((set) => set.length > 0);
+
+// 서버 졸업 규칙을 폼 입력용 draft로 변환한다.
+export const toRuleDraft = (rule: TAdminGraduationRule): TGraduationRuleDraft => {
+  const config = rule.ruleConfig;
+  return {
+    ...EMPTY_RULE_DRAFT,
+    clientId: `rule-${rule.id}`,
+    id: rule.id,
+    ruleTypeId: String(rule.ruleTypeId),
+    ruleName: rule.ruleName,
+    description: rule.description ?? '',
+    minCredits: readString(config.minCredits),
+    minGpa: readString(config.minGpa),
+    minCount: readString(config.minCount),
+    courseType: readString(config.courseType) as TCourseType | '',
+    areaNames: readStringArray(config.areaNames),
+    courseCodes: readStringArray(config.courseCodes).join(', '),
+    exemptEnglishLevels: readStringArray(config.exemptEnglishLevels).join(', '),
+    requiredEnglishLevels: readStringArray(config.requiredEnglishLevels).join(', '),
+    courseTypes: readCourseTypeArray(config.courseTypes),
+    targetCourseCodes: readStringArray(config.targetCourseCodes).join(', '),
+    prerequisiteCourseCodes: readStringArray(config.prerequisiteCourseCodes).join(', '),
+    conditionField: config.conditionField === 'englishLevel' ? 'englishLevel' : '',
+    conditionValue: readString(config.conditionValue),
+    exemptStudentTypes: readStringArray(config.exemptStudentTypes).join(', '),
+    requiredCourseSetsText: formatRequiredCourseSets(config.requiredCourseSets),
+  };
+};
+
+// 서버 졸업 요건 세트 상세를 폼 입력용 상태로 변환한다.
+export const toRequirementSetForm = (
+  set: {
+    id: number;
+    departmentId: number;
+    departmentName: string;
+    yearStart: number;
+    yearEnd: number;
+    version: number;
+    description: string | null;
+    sheetImageUrl: string | null;
+    active: boolean;
+  },
+  department?: TAdminDepartment,
+): TRequirementSetFormState => ({
+  id: set.id,
+  departmentId: set.departmentId,
+  collegeName: department?.collegeName ?? '',
+  departmentName: department?.departmentName ?? set.departmentName,
+  yearStart: String(set.yearStart),
+  yearEnd: String(set.yearEnd),
+  version: String(set.version),
+  description: set.description ?? '',
+  sheetImageUrl: set.sheetImageUrl ?? '',
+  active: set.active,
+});

--- a/src/pages/admin/graduationRequirements.tsx
+++ b/src/pages/admin/graduationRequirements.tsx
@@ -1,17 +1,172 @@
+import { useState } from 'react';
+
+import GraduationRuleFilters from '@/components/admin/graduationRuleFilters';
+import GraduationRuleForm from '@/components/admin/graduationRuleForm';
+import GraduationRuleTable from '@/components/admin/graduationRuleTable';
+import RequirementSetFilters from '@/components/admin/requirementSetFilters';
+import RequirementSetForm from '@/components/admin/requirementSetForm';
+import useGraduationRuleEditor from '@/hooks/admin/useGraduationRuleEditor';
+import useRequirementSetEditor from '@/hooks/admin/useRequirementSetEditor';
+
+type TGraduationRequirementTab = 'rules' | 'sets';
+
+const TABS: { key: TGraduationRequirementTab; label: string }[] = [
+  { key: 'rules', label: '졸업 규칙 관리' },
+  { key: 'sets', label: '졸업 세트 관리' },
+];
+
 export default function AdminGraduationRequirements() {
+  const [activeTab, setActiveTab] = useState<TGraduationRequirementTab>('rules');
+  const ruleEditor = useGraduationRuleEditor();
+  const setEditor = useRequirementSetEditor();
+
+  // 하단 규칙 테이블은 두 탭이 공유한다. 현재 탭에 따라 해당 컨트롤러로 선택을 위임한다.
+  const handleTableToggleAll = (checked: boolean) => {
+    if (activeTab === 'sets') {
+      setEditor.toggleAllRules(ruleEditor.rules, checked);
+      return;
+    }
+    ruleEditor.selectRows(checked);
+  };
+
+  const handleTableToggleRow = (ruleId: number, checked: boolean) => {
+    if (activeTab === 'sets') {
+      setEditor.toggleRule(ruleId, checked);
+      return;
+    }
+    ruleEditor.selectRow(ruleId, checked);
+  };
+
+  const selectedTableIds = activeTab === 'rules' ? ruleEditor.selectedIds : setEditor.ruleIds;
+
   return (
-    <main className="flex-1 bg-coolgray-10/60 px-10 py-12">
-      <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-6">
+    <main className="flex-1 bg-primary-30/30 px-10 py-12">
+      <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-8">
         <div className="flex flex-col gap-2">
-          <p className="text-body-m font-semibold text-primary-90">Admin Curriculum</p>
           <h1 className="text-heading-3 text-coolgray-90">졸업 요건 관리</h1>
-          <p className="text-body-m text-coolgray-60">
-            졸업 규칙과 요건 세트 관리는 다음 PR에서 같은 관리자 레이아웃 위에 연결합니다.
+          <p className="text-body-m text-coolgray-90">
+            졸업 규칙을 관리하고, 선택한 규칙들을 조합해 학과별 졸업 요건 세트를 구성합니다.
           </p>
         </div>
-        <div className="rounded-2xl border border-primary-60/20 bg-white p-10 text-body-m text-coolgray-60 shadow-sm">
-          PR2에서 graduation_rule 조회/등록/수정, PR3에서 requirement_set 조합 UI를 추가할 예정입니다.
+
+        <div className="flex justify-center">
+          <div className="flex rounded-full bg-white p-1 shadow-sm">
+            {TABS.map((tab) => (
+              <button
+                key={tab.key}
+                type="button"
+                onClick={() => setActiveTab(tab.key)}
+                className={`rounded-full px-8 py-3 text-button-m transition-colors ${
+                  activeTab === tab.key ? 'bg-primary-30 text-primary-90' : 'text-coolgray-60 hover:text-primary-60'
+                }`}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
         </div>
+
+        {ruleEditor.isRuleTypeError && (
+          <div className="rounded-2xl border border-alert/30 bg-white px-6 py-4 text-body-m text-alert">
+            규칙 종류 목록을 불러오지 못했습니다. 새 규칙 추가는 제한될 수 있습니다.
+          </div>
+        )}
+
+        {activeTab === 'rules' ? (
+          <>
+            <div className="grid gap-8 lg:grid-cols-2">
+              <div className="min-h-72 rounded-2xl border border-primary-60/20 bg-white p-8 shadow-sm flex flex-col gap-2">
+                <p className="text-body-l text-primary-90">졸업 규칙은 졸업 판정에 쓰이는 단일 조건을 정의합니다.</p>
+                <p className="text-body-m text-coolgray-90">
+                  규칙 종류마다 필요한 설정값이 다르므로, 규칙 종류를 먼저 고른 뒤 나타나는 입력칸을 채워 저장합니다.
+                  이미 존재하는 규칙이 있는지 반드시 확인 후 신규 등록해주세요.
+                </p>
+                <p className="text-body-m text-coolgray-90">없는 유형의 규칙인 경우 관리자에게 문의하세요.</p>
+                <p className="text-body-m text-primary-90">
+                  * 규칙명은 해당 규칙을 통과하지 못한 학생에게 미충족 사유로 안내되므로 명확한 문장으로 작성해주세요.
+                </p>
+                <p className="text-body-m text-primary-90">
+                  * 수정 시 DB에 즉시 반영되므로, 반드시 수정 내용을 검토한 뒤 저장해주세요.
+                </p>
+              </div>
+
+              <GraduationRuleFilters
+                ruleTypes={ruleEditor.ruleTypes}
+                selectedRuleTypeIds={ruleEditor.selectedRuleTypeIds}
+                selectedCourseTypes={ruleEditor.selectedCourseTypes}
+                onRuleTypeToggle={ruleEditor.onRuleTypeToggle}
+                onCourseTypeToggle={ruleEditor.onCourseTypeToggle}
+                onApply={ruleEditor.applyFilters}
+                onReset={ruleEditor.resetFilters}
+              />
+            </div>
+
+            <GraduationRuleForm
+              areaTypes={ruleEditor.areaTypes}
+              ruleTypes={ruleEditor.ruleTypes}
+              drafts={ruleEditor.drafts}
+              isSaving={ruleEditor.isSaving}
+              onAddNew={ruleEditor.addDraft}
+              onRemove={ruleEditor.removeDraft}
+              onChange={ruleEditor.changeDraft}
+              onSubmit={ruleEditor.submit}
+            />
+          </>
+        ) : (
+          <>
+            <div className="grid gap-8 lg:grid-cols-2">
+              <div className="min-h-72 rounded-2xl border border-primary-60/20 bg-white p-8 shadow-sm flex flex-col gap-2">
+                <p className="text-body-l text-primary-90">
+                  졸업 세트는 여러 졸업 규칙을 묶어 특정 학과-학번에 적용하는 졸업 판정 기준입니다.
+                </p>
+                <p className="text-body-m text-coolgray-90">
+                  기존 세트를 불러오거나 신규로 작성한 뒤, 아래 졸업 규칙 목록에서 포함할 규칙을 체크해 저장합니다.
+                </p>
+                <p className="text-body-m text-primary-90">
+                  * 수정 시 DB에 즉시 반영되므로, 반드시 수정 내용을 검토한 뒤 저장해주세요.
+                </p>
+              </div>
+
+              <RequirementSetFilters
+                colleges={setEditor.colleges}
+                departments={setEditor.filterDepartments}
+                selectedCollegeId={setEditor.filterCollegeId}
+                selectedDepartmentId={setEditor.filterDepartmentId}
+                yearInput={setEditor.filterYear}
+                isLoadingDepartments={setEditor.isFilterDepartmentsLoading}
+                onCollegeChange={setEditor.onCollegeChange}
+                onDepartmentChange={setEditor.onDepartmentChange}
+                onYearChange={setEditor.onYearChange}
+                onApply={setEditor.applyFilters}
+                onReset={setEditor.resetFilters}
+              />
+            </div>
+
+            <RequirementSetForm
+              colleges={setEditor.colleges}
+              departments={setEditor.formDepartments}
+              sets={setEditor.requirementSets}
+              selectedRuleCount={setEditor.ruleIds.size}
+              form={setEditor.form}
+              isSaving={setEditor.isSaving}
+              isLoadingDetail={setEditor.isLoadingDetail}
+              onChange={setEditor.changeForm}
+              onNew={setEditor.newSet}
+              onLoadSet={setEditor.loadSet}
+              onSubmit={setEditor.submit}
+            />
+          </>
+        )}
+
+        <GraduationRuleTable
+          rules={ruleEditor.rules}
+          selectedIds={selectedTableIds}
+          isLoading={ruleEditor.isRulesLoading}
+          isError={ruleEditor.isRulesError}
+          mode={activeTab === 'rules' ? 'rule' : 'set'}
+          onToggleAll={handleTableToggleAll}
+          onToggleRow={handleTableToggleRow}
+        />
       </div>
     </main>
   );

--- a/src/types/admin/TGetAcademicOrganizations.ts
+++ b/src/types/admin/TGetAcademicOrganizations.ts
@@ -1,0 +1,16 @@
+import type { TCommonResponse } from '@/types/common';
+
+export type TAdminCollege = {
+  id: number;
+  collegeName: string;
+};
+
+export type TAdminDepartment = {
+  id: number;
+  collegeId: number;
+  collegeName: string;
+  departmentName: string;
+};
+
+export type TGetCollegesResponse = TCommonResponse<TAdminCollege[]>;
+export type TGetDepartmentsResponse = TCommonResponse<TAdminDepartment[]>;

--- a/src/types/admin/TGetGraduationRules.ts
+++ b/src/types/admin/TGetGraduationRules.ts
@@ -1,0 +1,24 @@
+import type { TCommonResponse } from '@/types/common';
+import type { TCourseType } from '@/types/course';
+
+import type { TRuleTypeName } from './TGetRuleTypes';
+
+export type TGraduationRuleConfig = Record<string, unknown>;
+
+// GET /api/admin/graduation-rules 응답 항목
+export type TAdminGraduationRule = {
+  id: number;
+  ruleTypeId: number;
+  typeName: TRuleTypeName;
+  courseType: TCourseType | null;
+  ruleName: string;
+  ruleConfig: TGraduationRuleConfig;
+  description: string | null;
+};
+
+export type TGraduationRuleFilters = {
+  ruleTypeIds?: number[];
+  courseTypes?: TCourseType[];
+};
+
+export type TGetGraduationRulesResponse = TCommonResponse<TAdminGraduationRule[]>;

--- a/src/types/admin/TGetRuleTypes.ts
+++ b/src/types/admin/TGetRuleTypes.ts
@@ -1,0 +1,23 @@
+import type { TCommonResponse } from '@/types/common';
+import type { TCourseType } from '@/types/course';
+
+export type TRuleTypeName =
+  | 'TOTAL_CREDITS'
+  | 'GPA'
+  | 'MIN_AREA_CREDITS'
+  | 'REQUIRED_COURSE'
+  | 'ENGLISH_COURSE'
+  | 'PREREQUISITE'
+  | 'SCIENCE_EXPERIMENT'
+  | 'SCIENCE_CONFLICT'
+  | 'THESIS';
+
+// GET /api/admin/rule-types 응답 항목 — 졸업 규칙 폼/필터 선택지
+export type TAdminRuleType = {
+  id: number;
+  typeName: TRuleTypeName;
+  courseType: TCourseType | null;
+  description: string;
+};
+
+export type TGetRuleTypesResponse = TCommonResponse<TAdminRuleType[]>;

--- a/src/types/admin/TPutGraduationRules.ts
+++ b/src/types/admin/TPutGraduationRules.ts
@@ -1,0 +1,17 @@
+import type { TCommonResponse } from '@/types/common';
+
+import type { TGraduationRuleConfig } from './TGetGraduationRules';
+
+export type TGraduationRuleUpsertItem = {
+  id: number | null;
+  ruleTypeId: number;
+  ruleName: string;
+  ruleConfig: TGraduationRuleConfig;
+  description: string | null;
+};
+
+export type TGraduationRuleUpsertRequest = {
+  items: TGraduationRuleUpsertItem[];
+};
+
+export type TPutGraduationRulesResponse = TCommonResponse<number[]>;

--- a/src/types/admin/TRequirementSets.ts
+++ b/src/types/admin/TRequirementSets.ts
@@ -1,0 +1,41 @@
+import type { TCommonResponse } from '@/types/common';
+
+export type TRequirementSetFilters = {
+  collegeId?: number;
+  departmentId?: number;
+  year?: number;
+};
+
+export type TAdminRequirementSetSummary = {
+  id: number;
+  departmentId: number;
+  departmentName: string;
+  yearStart: number;
+  yearEnd: number;
+  version: number;
+  description: string | null;
+  sheetImageUrl: string | null;
+  active: boolean;
+};
+
+export type TAdminRequirementSetDetail = TAdminRequirementSetSummary & {
+  graduationRuleIds: number[];
+};
+
+export type TRequirementSetCreateRequest = {
+  collegeName: string;
+  departmentName: string;
+  yearStart: number;
+  yearEnd: number;
+  description: string | null;
+  sheetImageUrl: string | null;
+  active: boolean;
+  graduationRuleIds: number[];
+};
+
+export type TRequirementSetUpdateRequest = Omit<TRequirementSetCreateRequest, 'collegeName' | 'departmentName'>;
+
+export type TGetRequirementSetsResponse = TCommonResponse<TAdminRequirementSetSummary[]>;
+export type TGetRequirementSetDetailResponse = TCommonResponse<TAdminRequirementSetDetail>;
+export type TPostRequirementSetResponse = TCommonResponse<number>;
+export type TPutRequirementSetResponse = TCommonResponse<null>;


### PR DESCRIPTION
## 📋 작업 내용
- 관리자 졸업 요건 관리 UI 및 API 연동 구현

## 🎯 관련 이슈
- closes #60 

## 📝 변경 사항
### API 연동
- 규칙 종류·단과대·학과·졸업 규칙·요건 세트 조회 및 규칙 배치 업서트, 세트 생성/수정 API 함수 추가
- 도메인별 쿼리키 정의 및 저장 후 루트 키 무효화

### UI
- 규칙 탭: 다중 선택 필터 + 규칙 종류(typeName)별로 달라지는 ruleConfig 입력 폼
- 세트 탭: 단과대/학과/연도 필터 + 세트 폼(기존 세트 불러오기·신규 작성)
- 하단 규칙 목록 테이블을 두 탭이 공유(규칙 편집 선택 / 세트 포함 규칙 선택)

### 구조
- 규칙 종류별 설정 입력칸을 `GraduationRuleConfigFields`로 분리
- 탭별 상태·검증·저장 로직을 `useGraduationRuleEditor` / `useRequirementSetEditor`
  컨트롤러 훅으로 분리해 페이지는 탭 UI·공유 테이블·디스패처만 담당 (페이지 738→173줄)
- 관리자 폼 공용 컨트롤(`adminFormControls`: 입력 스타일·꺽쇠·라벨·텍스트입력) 추출,
  과목 분류 폼의 중복 제거

## 📸 스크린샷 (선택사항)
<!--
필요한 경우 스크린샷 첨부
-->
