### PR TITLE
[Refactor] QA 피드백 반영 및 졸업 요건 관리 UI 정리

### DIFF
--- a/src/components/admin/adminFormControls.tsx
+++ b/src/components/admin/adminFormControls.tsx
@@ -4,6 +4,10 @@ import type { ReactNode } from 'react';
 export const ADMIN_INPUT_CLASS =
   'w-full rounded-lg border border-coolgray-20 bg-white px-3 py-2 text-body-s text-coolgray-90 outline-none placeholder:text-coolgray-60 focus:border-primary-60 disabled:bg-coolgray-10 disabled:text-coolgray-60';
 
+// 한 줄에 라벨+컨트롤을 좁게 배치하는 컴팩트 입력 스타일. (너비 w-* 는 사용처에서 덧붙인다)
+export const ADMIN_COMPACT_INPUT_CLASS =
+  'rounded-lg border border-coolgray-20 bg-white px-2 py-1.5 text-body-s text-coolgray-90 outline-none placeholder:text-coolgray-60 focus:border-primary-60 disabled:bg-coolgray-10 disabled:text-coolgray-60';
+
 // 네이티브 화살표를 숨긴 select(appearance-none) 위에 커스텀 꺽쇠를 칸 안쪽으로 들여 그린다.
 export function SelectChevron() {
   return (

--- a/src/components/admin/graduationRuleTable.tsx
+++ b/src/components/admin/graduationRuleTable.tsx
@@ -1,3 +1,4 @@
+import TruncatedCell from '@/components/admin/truncatedCell';
 import type { TAdminGraduationRule } from '@/types/admin/TGetGraduationRules';
 import { COURSE_LABEL } from '@/types/course';
 
@@ -54,11 +55,11 @@ export default function GraduationRuleTable({
         <table className="min-w-[1120px] w-full table-fixed border-collapse bg-white">
           <colgroup>
             <col className="w-12" />
-            <col className="w-[22%]" />
+            <col className="w-[32%]" />
             <col className="w-[18%]" />
-            <col className="w-[12%]" />
-            <col className="w-[30%]" />
-            <col className="w-[18%]" />
+            <col className="w-[8%]" />
+            <col className="w-[28%]" />
+            <col className="w-[14%]" />
           </colgroup>
           <thead className="sticky top-0 z-10 bg-primary-30">
             <tr>
@@ -119,16 +120,19 @@ export default function GraduationRuleTable({
                       aria-label={`${rule.ruleName} 선택`}
                     />
                   </td>
-                  <td className={`${BODY_CELL_CLASS} font-semibold`}>
-                    <span className="block truncate">{rule.ruleName}</span>
+                  <td className={BODY_CELL_CLASS}>
+                    {/* 규칙명이 길어 ...로 잘릴 때 커서를 올리면 전체 규칙명을 툴팁으로 보여준다. */}
+                    <TruncatedCell text={rule.ruleName} className="font-semibold" />
                   </td>
                   <td className={BODY_CELL_CLASS}>{rule.typeName}</td>
                   <td className={BODY_CELL_CLASS}>{rule.courseType ? COURSE_LABEL[rule.courseType] : '전체'}</td>
                   <td className={BODY_CELL_CLASS}>
-                    <span className="block truncate">{formatConfig(rule.ruleConfig)}</span>
+                    {/* 설정값도 길어지면 잘리므로 hover 시 전체 값을 툴팁으로 노출한다. */}
+                    <TruncatedCell text={formatConfig(rule.ruleConfig)} />
                   </td>
                   <td className={BODY_CELL_CLASS}>
-                    <span className="block truncate">{rule.description ?? '-'}</span>
+                    {/* 설명도 동일하게 hover 시 전체 내용을 확인할 수 있게 한다. */}
+                    <TruncatedCell text={rule.description ?? '-'} />
                   </td>
                 </tr>
               ))}

--- a/src/components/admin/requirementSetFilters.tsx
+++ b/src/components/admin/requirementSetFilters.tsx
@@ -1,4 +1,4 @@
-import { ADMIN_INPUT_CLASS } from '@/components/admin/adminFormControls';
+import { ADMIN_COMPACT_INPUT_CLASS } from '@/components/admin/adminFormControls';
 import type { TAdminCollege, TAdminDepartment } from '@/types/admin/TGetAcademicOrganizations';
 
 interface IRequirementSetFiltersProps {
@@ -15,8 +15,6 @@ interface IRequirementSetFiltersProps {
   onReset: () => void;
 }
 
-const INPUT_CLASS = ADMIN_INPUT_CLASS;
-
 export default function RequirementSetFilters({
   colleges,
   departments,
@@ -30,73 +28,65 @@ export default function RequirementSetFilters({
   onApply,
   onReset,
 }: IRequirementSetFiltersProps) {
+  // 졸업 세트 필터: 버전·활성 정책 콜아웃 아래에 단과대·학과·적용년도·필터적용·초기화를 한 줄로 작게 배치한다.
   return (
-    <section className="flex h-full flex-col gap-5 rounded-2xl border border-coolgray-10 bg-white p-8 shadow-sm">
-      <div>
-        <h2 className="text-heading-5 text-coolgray-90">졸업 세트 필터</h2>
-        <p className="mt-1 text-body-s text-coolgray-60">단과대, 학과, 적용 연도로 기존 졸업 요건 세트를 조회합니다.</p>
-      </div>
-
-      <div className="grid grid-cols-2 gap-3">
-        <label className="flex flex-col gap-1.5">
-          <span className="text-body-s font-semibold text-coolgray-90">단과대</span>
-          <select
-            value={selectedCollegeId}
-            onChange={(event) => onCollegeChange(event.target.value)}
-            className={INPUT_CLASS}
-          >
-            <option value="">전체 단과대</option>
-            {colleges.map((college) => (
-              <option key={college.id} value={college.id}>
-                {college.collegeName}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label className="flex flex-col gap-1.5">
-          <span className="text-body-s font-semibold text-coolgray-90">학과</span>
-          <select
-            value={selectedDepartmentId}
-            disabled={isLoadingDepartments}
-            onChange={(event) => onDepartmentChange(event.target.value)}
-            className={INPUT_CLASS}
-          >
-            <option value="">{isLoadingDepartments ? '학과 불러오는 중' : '전체 학과'}</option>
-            {departments.map((department) => (
-              <option key={department.id} value={department.id}>
-                {department.departmentName}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label className="flex flex-col gap-1.5">
-          <span className="text-body-s font-semibold text-coolgray-90">적용 연도</span>
-          <input
-            value={yearInput}
-            inputMode="numeric"
-            placeholder="예: 2023"
-            onChange={(event) => onYearChange(event.target.value)}
-            className={INPUT_CLASS}
-          />
-        </label>
-      </div>
-
-      <div className="mt-auto flex justify-end gap-2">
-        <button
-          type="button"
-          className="rounded-full px-5 py-2 text-button-s text-coolgray-60 cursor-pointer"
-          onClick={onReset}
+    <div className="flex flex-wrap items-end gap-2">
+      <label className="flex flex-col gap-1">
+        <span className="text-body-xs font-semibold text-coolgray-60">단과대</span>
+        <select
+          value={selectedCollegeId}
+          onChange={(event) => onCollegeChange(event.target.value)}
+          className={`${ADMIN_COMPACT_INPUT_CLASS} w-50`}
         >
-          초기화
-        </button>
-        <button
-          type="button"
-          className="rounded-full bg-primary-60 px-5 py-2 text-button-s text-white hover:opacity-90 cursor-pointer"
-          onClick={onApply}
+          <option value="">전체 단과대</option>
+          {colleges.map((college) => (
+            <option key={college.id} value={college.id}>
+              {college.collegeName}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="flex flex-col gap-1">
+        <span className="text-body-xs font-semibold text-coolgray-60">학과</span>
+        <select
+          value={selectedDepartmentId}
+          disabled={isLoadingDepartments}
+          onChange={(event) => onDepartmentChange(event.target.value)}
+          className={`${ADMIN_COMPACT_INPUT_CLASS} w-50`}
         >
-          필터 적용
-        </button>
-      </div>
-    </section>
+          <option value="">{isLoadingDepartments ? '학과 불러오는 중' : '전체 학과'}</option>
+          {departments.map((department) => (
+            <option key={department.id} value={department.id}>
+              {department.departmentName}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="flex flex-col gap-1">
+        <span className="text-body-xs font-semibold text-coolgray-60">적용년도</span>
+        <input
+          value={yearInput}
+          inputMode="numeric"
+          placeholder="예: 2023"
+          onChange={(event) => onYearChange(event.target.value)}
+          className={`${ADMIN_COMPACT_INPUT_CLASS} w-50`}
+        />
+      </label>
+      {/* 버튼은 라벨 높이만큼 처지지 않도록 mb-1로 입력칸 높이에 맞춰 정렬한다. */}
+      <button
+        type="button"
+        className="rounded-full bg-primary-60 px-4 py-1.5 mb-1 text-button-s text-white hover:opacity-90 cursor-pointer"
+        onClick={onApply}
+      >
+        필터 적용
+      </button>
+      <button
+        type="button"
+        className="rounded-full bg-white px-4 py-1.5 mb-1 text-button-s text-coolgray-60 hover:opacity-90 cursor-pointer"
+        onClick={onReset}
+      >
+        초기화
+      </button>
+    </div>
   );
 }

--- a/src/components/admin/requirementSetForm.tsx
+++ b/src/components/admin/requirementSetForm.tsx
@@ -1,4 +1,6 @@
-import { ADMIN_INPUT_CLASS } from '@/components/admin/adminFormControls';
+import type { ReactNode } from 'react';
+
+import { ADMIN_COMPACT_INPUT_CLASS, ADMIN_INPUT_CLASS } from '@/components/admin/adminFormControls';
 import Button from '@/components/common/button';
 import type { TAdminCollege, TAdminDepartment } from '@/types/admin/TGetAcademicOrganizations';
 import type { TAdminRequirementSetSummary } from '@/types/admin/TRequirementSets';
@@ -28,6 +30,8 @@ interface IRequirementSetFormProps {
   onNew: () => void;
   onLoadSet: (setId: number) => void;
   onSubmit: () => void;
+  // 버전·활성 정책 콜아웃 아래에 한 줄로 노출할 졸업 세트 필터 슬롯. (인라인 형태의 RequirementSetFilters)
+  filterSlot?: ReactNode;
 }
 
 const INPUT_CLASS = ADMIN_INPUT_CLASS;
@@ -44,6 +48,7 @@ export default function RequirementSetForm({
   onNew,
   onLoadSet,
   onSubmit,
+  filterSlot,
 }: IRequirementSetFormProps) {
   const isEditMode = form.id !== null;
 
@@ -84,27 +89,34 @@ export default function RequirementSetForm({
         </p>
       </div>
 
-      <div className="grid gap-4 lg:grid-cols-[1fr_1fr_1fr]">
-        <label className="flex flex-col gap-1.5">
-          <span className="text-body-s font-semibold text-coolgray-90">기존 세트 불러오기</span>
-          <select
-            value={form.id ?? ''}
-            disabled={isSaving || isLoadingDetail}
-            onChange={(event) => {
-              if (!event.target.value) return;
-              onLoadSet(Number(event.target.value));
-            }}
-            className={INPUT_CLASS}
-          >
-            <option value="">선택</option>
-            {sets.map((set) => (
-              <option key={set.id} value={set.id}>
-                {set.departmentName} · {set.yearStart}-{set.yearEnd} · v{set.version}
-              </option>
-            ))}
-          </select>
-        </label>
+      {/* 졸업 세트 필터 + 기존 세트 불러오기: 본문 입력값과 구분되도록 primary-30 음영·테두리 박스로 묶고, 불러오기는 오른쪽에 둔다. */}
+      <div className="flex flex-col gap-2 rounded-xl border border-primary-60/20 bg-primary-30 p-4">
+        <span className="text-body-s font-semibold text-primary-90">졸업 세트 필터</span>
+        <div className="flex flex-wrap items-end gap-4">
+          {filterSlot}
+          <label className="ml-auto flex flex-col gap-1">
+            <span className="text-body-xs font-semibold text-coolgray-60">기존 세트 불러오기</span>
+            <select
+              value={form.id ?? ''}
+              disabled={isSaving || isLoadingDetail}
+              onChange={(event) => {
+                if (!event.target.value) return;
+                onLoadSet(Number(event.target.value));
+              }}
+              className={`${ADMIN_COMPACT_INPUT_CLASS} w-64`}
+            >
+              <option value="">선택</option>
+              {sets.map((set) => (
+                <option key={set.id} value={set.id}>
+                  {set.departmentName} · {set.yearStart}-{set.yearEnd} · v{set.version}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </div>
 
+      <div className="grid gap-4 lg:grid-cols-[1fr_1fr_1fr]">
         <label className="flex flex-col gap-1.5">
           <span className="text-body-s font-semibold text-coolgray-90">단과대</span>
           <input

--- a/src/components/admin/truncatedCell.tsx
+++ b/src/components/admin/truncatedCell.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 interface ITruncatedCellProps {
@@ -27,6 +27,15 @@ export default function TruncatedCell({ text, className = '' }: ITruncatedCellPr
   };
 
   const handleMouseLeave = () => setTooltipPos(null);
+
+  // 툴팁은 fixed 위치라 한 번 띄운 좌표에 고정된다. 테이블/페이지를 스크롤하면 셀과 어긋나므로,
+  // 툴팁이 떠 있는 동안 스크롤이 감지되면(캡처 단계로 내부 스크롤까지 포함) 툴팁을 닫는다.
+  useEffect(() => {
+    if (!tooltipPos) return;
+    const handleScroll = () => setTooltipPos(null);
+    window.addEventListener('scroll', handleScroll, { capture: true });
+    return () => window.removeEventListener('scroll', handleScroll, { capture: true });
+  }, [tooltipPos]);
 
   return (
     <>

--- a/src/components/admin/truncatedCell.tsx
+++ b/src/components/admin/truncatedCell.tsx
@@ -1,0 +1,53 @@
+import { useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+interface ITruncatedCellProps {
+  // 한 줄로 축약해 보여줄 텍스트
+  text: string;
+  // 텍스트 span에 덧붙일 추가 클래스 (폰트 두께 등)
+  className?: string;
+}
+
+// 좁은 셀에서 텍스트가 ...로 잘릴 때, 커서를 올리면 전체 내용을 툴팁으로 보여주는 셀.
+// 테이블 컨테이너가 overflow-auto라 일반 absolute 툴팁은 잘리므로,
+// portal + fixed 위치로 body에 띄워 잘림 없이 표시한다.
+export default function TruncatedCell({ text, className = '' }: ITruncatedCellProps) {
+  const textRef = useRef<HTMLSpanElement>(null);
+  // 툴팁이 떠야 할 화면 좌표. null이면 숨김.
+  const [tooltipPos, setTooltipPos] = useState<{ top: number; left: number } | null>(null);
+
+  const handleMouseEnter = () => {
+    const el = textRef.current;
+    if (!el) return;
+    // 실제로 잘린 경우(콘텐츠 너비 > 보이는 너비)에만 툴팁을 띄운다.
+    if (el.scrollWidth <= el.clientWidth) return;
+    const rect = el.getBoundingClientRect();
+    // 셀 바로 아래에 툴팁을 띄운다.
+    setTooltipPos({ top: rect.bottom + 6, left: rect.left });
+  };
+
+  const handleMouseLeave = () => setTooltipPos(null);
+
+  return (
+    <>
+      <span
+        ref={textRef}
+        className={`block truncate ${className}`}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      >
+        {text}
+      </span>
+      {tooltipPos &&
+        createPortal(
+          <div
+            className="pointer-events-none fixed z-[200] max-w-md whitespace-normal break-words rounded-lg bg-coolgray-90 px-3 py-2 text-body-xs text-white shadow-lg"
+            style={{ top: tooltipPos.top, left: tooltipPos.left }}
+          >
+            {text}
+          </div>,
+          document.body,
+        )}
+    </>
+  );
+}

--- a/src/components/common/footer.tsx
+++ b/src/components/common/footer.tsx
@@ -3,7 +3,7 @@ import { toast } from 'sonner';
 
 import Github from '@/assets/github.svg?react';
 import Logo from '@/assets/logo.svg?react';
-import { KAKAO_CHAT_URL, READY_MESSAGE } from '@/constants/links';
+import { KAKAO_CHAT_URL, PRIVACY_POLICY_URL, READY_MESSAGE, TERMS_OF_SERVICE_URL } from '@/constants/links';
 
 // 항목별 동작 구분: 실제 페이지(link), 외부 링크(external), 미개발 안내(toast).
 const NAV_ITEMS = [
@@ -12,7 +12,8 @@ const NAV_ITEMS = [
   { name: '고객지원', type: 'external', href: KAKAO_CHAT_URL },
   { name: '동그리 소개', type: 'toast' },
   { name: '자주 묻는 질문', type: 'toast' },
-  { name: '개인정보처리방침', type: 'toast' },
+  { name: '개인정보처리방침', type: 'external', href: PRIVACY_POLICY_URL },
+  { name: '서비스이용약관', type: 'external', href: TERMS_OF_SERVICE_URL },
 ] as const;
 
 // 모든 항목이 공유하는 스타일.

--- a/src/components/onBoardingModal.tsx
+++ b/src/components/onBoardingModal.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import Button from '@/components/common/button';
 import TextField from '@/components/common/textField';
+import { TERMS_OF_SERVICE_URL } from '@/constants/links';
 import useOnboarding from '@/hooks/auth/useOnboarding';
 import { useModalStore } from '@/stores/modalStore';
 import { validateName, validateStudentId } from '@/utils/validators';
@@ -18,6 +19,8 @@ export default function OnBoardingModal() {
   const [agreedPrivacy, setAgreedPrivacy] = useState(false);
   const [agreedTerms, setAgreedTerms] = useState(false);
   const [agreedAge, setAgreedAge] = useState(false);
+  // 개인정보 수집·이용 동의의 '자세히' 토글: 펼치면 수집 항목 안내를 아래로 보여준다.
+  const [showPrivacyDetail, setShowPrivacyDetail] = useState(false);
 
   if (type !== 'onboarding') return null;
 
@@ -44,6 +47,9 @@ export default function OnBoardingModal() {
     setTouched((prev) => ({ ...prev, studentId: true }));
     setStudentIdError(validateStudentId(value));
   };
+
+  // 이름·학번 입력과 필수 동의 3개가 모두 채워지기 전에는 제출 버튼을 비활성(회색)으로 둔다.
+  const isSubmitDisabled = !name || !studentId || !agreedAge || !agreedPrivacy || !agreedTerms || isPending;
 
   // 온보딩 정보 저장. 성공 시 홈 이동은 useOnboarding이 처리하고, 여기서는 모달만 닫는다.
   const handleSubmit = () => {
@@ -112,12 +118,30 @@ export default function OnBoardingModal() {
             />
             <span className="text-body-m">
               [필수] 개인정보 수집·이용 동의 (
-              <a href="#" target="_blank" rel="noopener noreferrer" className="underline">
+              {/* '자세히'는 외부 링크가 아니라 아래로 펼쳐지는 토글. label 안에 있으므로 클릭이 체크박스로 전파되지 않게 막는다. */}
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setShowPrivacyDetail((prev) => !prev);
+                }}
+                className="underline cursor-pointer"
+              >
                 자세히
-              </a>
+              </button>
               )
             </span>
           </label>
+          {/* 개인정보 수집·이용 동의 상세: '자세히'를 누르면 펼쳐진다. */}
+          {showPrivacyDetail && (
+            <div className="ml-7 flex flex-col gap-1 rounded-lg bg-coolgray-10 px-4 py-3 text-body-s text-coolgray-90">
+              <span>▸ 수집 목적: 회원 식별, 서비스 제공</span>
+              <span>▸ 수집 항목: 이름, 학번, 이메일</span>
+              <span>▸ 보유 기간: 회원 탈퇴 시까지 (관련 법령에 따라 일정 기간 보관)</span>
+              <span>▸ 거부 권리: 동의를 거부할 수 있으나, 거부 시 서비스 이용이 제한됩니다.</span>
+            </div>
+          )}
           <label className="flex items-center gap-3 cursor-pointer">
             <input
               type="checkbox"
@@ -127,7 +151,14 @@ export default function OnBoardingModal() {
             />
             <span className="text-body-m">
               [필수] 서비스 이용약관 동의 (
-              <a href="#" target="_blank" rel="noopener noreferrer" className="underline">
+              {/* 클릭이 체크박스 토글로 전파되지 않도록 막고, 약관 문서를 새 탭으로 연다. */}
+              <a
+                href={TERMS_OF_SERVICE_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={(e) => e.stopPropagation()}
+                className="underline"
+              >
                 자세히
               </a>
               )
@@ -135,9 +166,10 @@ export default function OnBoardingModal() {
           </label>
         </div>
         <Button
+          variant={isSubmitDisabled ? 'disabled' : 'primary'}
           className="w-full text-body-l py-3"
           onClick={handleSubmit}
-          disabled={!name || !studentId || !agreedAge || !agreedPrivacy || !agreedTerms || isPending}
+          disabled={isSubmitDisabled}
         >
           동그리 시작하기
         </Button>

--- a/src/constants/links.ts
+++ b/src/constants/links.ts
@@ -3,5 +3,13 @@
 // 고객지원: 카카오 채널 채팅 주소.
 export const KAKAO_CHAT_URL = 'http://pf.kakao.com/_UxnFGX/chat';
 
+// 개인정보처리방침 안내(노션 문서).
+export const PRIVACY_POLICY_URL =
+  'https://mybluespring.notion.site/38ea6ce30c6e80aeadeadbb076d7ac96?v=38ea6ce30c6e80af8232000c1f96b20f&source=copy_link';
+
+// 서비스 이용약관 안내(노션 문서).
+export const TERMS_OF_SERVICE_URL =
+  'https://mybluespring.notion.site/38ea6ce30c6e807a9732e9dd88ec09c9?v=38ea6ce30c6e801796d4000c49b520f1&source=copy_link';
+
 // 아직 개발되지 않은 기능 클릭 시 보여줄 토스트 문구.
 export const READY_MESSAGE = '준비 중인 기능입니다.';

--- a/src/pages/admin/graduationRequirements.tsx
+++ b/src/pages/admin/graduationRequirements.tsx
@@ -127,18 +127,15 @@ export default function AdminGraduationRequirements() {
                 </p>
               </div>
 
-              <RequirementSetFilters
-                colleges={setEditor.colleges}
-                departments={setEditor.filterDepartments}
-                selectedCollegeId={setEditor.filterCollegeId}
-                selectedDepartmentId={setEditor.filterDepartmentId}
-                yearInput={setEditor.filterYear}
-                isLoadingDepartments={setEditor.isFilterDepartmentsLoading}
-                onCollegeChange={setEditor.onCollegeChange}
-                onDepartmentChange={setEditor.onDepartmentChange}
-                onYearChange={setEditor.onYearChange}
-                onApply={setEditor.applyFilters}
-                onReset={setEditor.resetFilters}
+              {/* 세트 관리 탭에서도 하단 졸업 규칙 목록을 좁힐 수 있도록 규칙 관리 탭과 동일한 졸업 규칙 필터를 둔다. */}
+              <GraduationRuleFilters
+                ruleTypes={ruleEditor.ruleTypes}
+                selectedRuleTypeIds={ruleEditor.selectedRuleTypeIds}
+                selectedCourseTypes={ruleEditor.selectedCourseTypes}
+                onRuleTypeToggle={ruleEditor.onRuleTypeToggle}
+                onCourseTypeToggle={ruleEditor.onCourseTypeToggle}
+                onApply={ruleEditor.applyFilters}
+                onReset={ruleEditor.resetFilters}
               />
             </div>
 
@@ -154,6 +151,22 @@ export default function AdminGraduationRequirements() {
               onNew={setEditor.newSet}
               onLoadSet={setEditor.loadSet}
               onSubmit={setEditor.submit}
+              // 기존 졸업 세트 필터는 세트 폼 내부(버전·활성 정책 콜아웃 아래)에 한 줄로 배치한다.
+              filterSlot={
+                <RequirementSetFilters
+                  colleges={setEditor.colleges}
+                  departments={setEditor.filterDepartments}
+                  selectedCollegeId={setEditor.filterCollegeId}
+                  selectedDepartmentId={setEditor.filterDepartmentId}
+                  yearInput={setEditor.filterYear}
+                  isLoadingDepartments={setEditor.isFilterDepartmentsLoading}
+                  onCollegeChange={setEditor.onCollegeChange}
+                  onDepartmentChange={setEditor.onDepartmentChange}
+                  onYearChange={setEditor.onYearChange}
+                  onApply={setEditor.applyFilters}
+                  onReset={setEditor.resetFilters}
+                />
+              }
             />
           </>
         )}

--- a/src/pages/graduation.tsx
+++ b/src/pages/graduation.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
 
 import Chart from '@/assets/icons/chart.svg?react';
 import Warning from '@/assets/icons/warning.svg?react';
@@ -9,6 +10,7 @@ import CourseSummaryCard from '@/components/courseSummaryCard';
 import CourseTabView from '@/components/courseTabView';
 import ProgressBar from '@/components/progressBar';
 import { ERROR_CODE } from '@/constants/errorCodes';
+import { READY_MESSAGE } from '@/constants/links';
 import { TRANSCRIPT_ERROR_MODAL } from '@/constants/report/transcriptErrorModals';
 import useReportSummary from '@/hooks/report/useReportSummary';
 import useInView from '@/hooks/useInView';
@@ -166,7 +168,8 @@ export default function Graduation() {
         <Button variant="outlined" className="w-60" onClick={() => navigate('/my-page/academic-records')}>
           내 학업 정보 수정
         </Button>
-        <Button className="w-60" onClick={() => navigate('/curriculum')}>
+        {/* 커리큘럼 기능은 아직 미개발이라 페이지 이동 대신 준비 중 토스트로 안내한다. */}
+        <Button className="w-60" onClick={() => toast(READY_MESSAGE)}>
           커리큘럼 확인하기
         </Button>
       </div>


### PR DESCRIPTION
## 📋 작업 내용
- QA 피드백을 반영하고, 졸업 요건 관리 화면의 필터 구성을 정리

## 🎯 관련 이슈
- closes #63 

## 📝 변경 사항
### 사용자 화면
- 학업 리포트: '커리큘럼 확인하기' 버튼이 미개발 커리큘럼 페이지로 이동하던 것을, 다른 진입점과 동일하게 '준비 중인 기능입니다' 토스트 안내로 통일
- 온보딩 모달
  - 이름·학번 입력과 필수 동의 3개가 모두 채워지기 전에는 제출 버튼을 회색(disabled)으로 표시
  - '서비스 이용약관 동의 > 자세히' → 약관 노션 문서 새 탭 링크 연결
  - '개인정보 수집·이용 동의 > 자세히' → 클릭 시 수집 목적/항목/보유 기간/거부 권리 안내가 아래로 펼쳐지는 토글로 변경
  - '자세히' 클릭이 동의 체크박스를 토글하지 않도록 이벤트 전파 차단
- 푸터: '개인정보처리방침'을 외부 링크로 연결하고, 그 옆에 '서비스이용약관' 링크 항목 추가

### 관리자 - 졸업 요건 관리
- 졸업 세트 관리 탭의 필터 자리를 졸업 규칙 관리 탭과 동일한 '졸업 규칙 필터'로 대체 (하단 공유 규칙 목록을 좁히는 용도)
- 기존 졸업 세트 필터는 세트 폼 내부(버전·활성 정책 콜아웃 아래)로 이동해, primary-30 음영 박스 안에 '단과대·학과·적용년도·필터 적용·초기화 + 기존 세트 불러오기'를 한 줄로 묶어 배치
- 졸업 규칙 목록에서 규칙명·설정값·설명이 길어 잘릴 때, 커서를 올리면 전체 내용을 보여주는 툴팁 추가 (overflow 잘림 방지를 위해 portal + fixed 위치 사용, 실제로 잘린 경우에만 표시)

### 리팩토링
- 더 이상 사용하지 않는 RequirementSetFilters의 panel variant 및 variant prop 제거
- 중복되던 컴팩트 입력 스타일을 `ADMIN_COMPACT_INPUT_CLASS`로 공용화

## 📸 스크린샷 (선택사항)
<!--
필요한 경우 스크린샷 첨부
-->
